### PR TITLE
feat: 공통코드 관리 기능 구현 (#21)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeController.java
@@ -1,0 +1,187 @@
+package com.ocp.ocp_finalproject.admin.controller;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCode;
+import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
+import com.ocp.ocp_finalproject.admin.dto.request.CommonCodeRequest;
+import com.ocp.ocp_finalproject.admin.dto.response.CommonCodeResponse;
+import com.ocp.ocp_finalproject.admin.service.CommonCodeGroupService;
+import com.ocp.ocp_finalproject.admin.service.CommonCodeService;
+import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "공통코드")
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class CommonCodeController {
+
+    private final CommonCodeService commonCodeService;
+    private final CommonCodeGroupService commonCodeGroupService;
+
+    // 공통 코드 생성
+    @Operation(summary = "공통코드 생성", description = "새로운 공통코드를 생성합니다.")
+    @PostMapping("/common-codes")
+    public ResponseEntity<ApiResponse<CommonCodeResponse>> createCode(
+            @Valid @RequestBody CommonCodeRequest request){
+
+        // 그룹 조회
+        CommonCodeGroup group = commonCodeGroupService.getGroup(request.getGroupId());
+
+        // 코드 생성
+        CommonCode code = CommonCode.createBuilder()
+                .codeId(request.getCodeId())
+                .commonCodeGroup(group)
+                .codeName(request.getCodeName())
+                .description(request.getDescription())
+                .sortOrder(request.getSortOrder())
+                .isActive(request.getIsActive())
+                .build();
+
+        CommonCode saveCode = commonCodeService.createCode(code);
+        CommonCodeResponse response = CommonCodeResponse.from(saveCode);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 생성 완료", response));
+    }
+
+    // 공통 코드 단건 조회
+    @Operation(summary = "공통코드 단건 조회", description = "그룹 ID와 코드 ID로 공통코드를 조회합니다.")
+    @GetMapping("/common-codes/{groupId}/{codeId}")
+    public ResponseEntity<ApiResponse<CommonCodeResponse>> getCode(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId,
+            @Parameter(description = "코드 ID") @PathVariable String codeId){
+
+        CommonCode code = commonCodeService.getCode(codeId);
+        CommonCodeResponse response = CommonCodeResponse.from(code);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 조회 성공", response));
+    }
+
+    // 그룹별 코드 목록 조회(리스트)
+    @Operation(summary = "그룹별 코드 목록 조회", description = "특정 그룹의 모든 코드를 정렬 순서대로 조회합니다.")
+    @GetMapping("/common-codes/{groupId}")
+    public ResponseEntity<ApiResponse<List<CommonCodeResponse>>> getCodesByGroup(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId){
+
+        List<CommonCode> codes = commonCodeService.getCodesByGroupId(groupId);
+        List<CommonCodeResponse> response = codes.stream()
+                .map(CommonCodeResponse::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success("그룹별 코드 목록 조회 성공", response));
+    }
+
+    // 그룹별 코드 목록 조회 (페이징)
+    @Operation(summary = "그룹별 코드 목록 조회(페이징)", description = "특정 그룹의 코드를 페이징하여 조회합니다.")
+    @GetMapping("/common-codes/{groupId}/paged")
+    public ResponseEntity<ApiResponse<Page<CommonCodeResponse>>> getPagedCode(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId,
+            @ParameterObject Pageable pageable){
+
+        Page<CommonCode> codes = commonCodeService.getCodesByGroupIdPaged(groupId, pageable);
+        Page<CommonCodeResponse> responses = codes.map(CommonCodeResponse::from);
+        return ResponseEntity.ok(ApiResponse.success("그룹별 코드 목록 조회 성공", responses));
+    }
+
+    // 활성화된 코드만 조회
+    @Operation(summary = "활성화된 코드 조회", description = "특정 그룹의 활성화된 코드만 조회합니다.")
+    @GetMapping("/common-codes/{groupId}/active")
+    public ResponseEntity<ApiResponse<List<CommonCodeResponse>>> getActiveCodesByGroup(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId){
+
+        List<CommonCode> codes = commonCodeService.getActiveCodesByGroupId(groupId);
+        List<CommonCodeResponse> responses = codes.stream()
+                .map(CommonCodeResponse::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(ApiResponse.success("활성 코드 목록 조회 성공", responses));
+    }
+
+    // 공통코드 검색
+    @Operation(summary = "공통코드 검색", description = "그룹, 코드명, 활성화 상태로 검색합니다.")
+    @GetMapping("/common-codes/search")
+    public ResponseEntity<ApiResponse<Page<CommonCodeResponse>>> searchCode(
+            @Parameter(description = "그룹 ID") @RequestParam(required = false) String groupId,
+            @Parameter(description = "코드명") @RequestParam(required = false) String codeName,
+            @Parameter(description = "활성화 여부") @RequestParam(required = false) Boolean isActive,
+            @ParameterObject Pageable pageable){
+
+            Page<CommonCode> codes = commonCodeService.searchCodes(groupId, codeName, isActive, pageable);
+            Page<CommonCodeResponse> responses = codes.map(CommonCodeResponse::from);
+            return ResponseEntity.ok(ApiResponse.success("공통코드 검색 완료", responses));
+    }
+
+    // 코드 정보 수정
+    @Operation(summary = "공통코드 수정", description = "공통코드 정보를 수정합니다.")
+    @PutMapping("/common-codes/{groupId}/{codeId}")
+    public ResponseEntity<ApiResponse<CommonCodeResponse>> updateCode(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId,
+            @Parameter(description = "코드 ID") @PathVariable String codeId,
+            @Valid @RequestBody CommonCodeRequest request){
+
+        commonCodeService.updateCode(
+                codeId,
+                request.getCodeName(),
+                request.getDescription(),
+                request.getSortOrder()
+        );
+
+        CommonCode updateCode = commonCodeService.getCode(codeId);
+        CommonCodeResponse response = CommonCodeResponse.from(updateCode);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 수정 완료", response));
+    }
+
+    // 코드 활성화
+    @Operation(summary = "공통코드 활성화", description = "공통코드를 활성화합니다.")
+    @PatchMapping("/common-codes/{groupId}/{codeId}/activate")
+    public ResponseEntity<ApiResponse<CommonCodeResponse>> activateCode(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId,
+            @Parameter(description = "코드 ID")  @PathVariable String codeId){
+
+        commonCodeService.activateCode(codeId);
+        CommonCode code = commonCodeService.getCode(codeId);
+        CommonCodeResponse response = CommonCodeResponse.from(code);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 활성화 완료", response));
+    }
+
+    // 코드 비활성화
+    @Operation(summary = "공통코드 비활성화", description = "공통코드를 비활성화합니다.")
+    @PatchMapping("/common-codes/{groupId}/{codeId}/deactivate")
+    public ResponseEntity<ApiResponse<CommonCodeResponse>> deactivateCode(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId,
+            @Parameter(description = "코드 ID") @PathVariable String codeId){
+
+        commonCodeService.deactivateCode(codeId);
+        CommonCode code = commonCodeService.getCode(codeId);
+        CommonCodeResponse response = CommonCodeResponse.from(code);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 비활성화 완료", response));
+    }
+
+    // 그룹별 코드 개수 조회
+    @Operation(summary = "그룹별 코드 개수", description = "특정 그룹의 전체 코드 개수를 조회합니다.")
+    @GetMapping("/common-codes/{groupId}/count")
+    public ResponseEntity<ApiResponse<Long>> getCodeCountByGroup(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId){
+
+        long count = commonCodeService.countByGroupId(groupId);
+        return ResponseEntity.ok(ApiResponse.success("코드 개수 조회 성공", count));
+    }
+
+    // 그룹별 활성 코드 개수 조회
+    @Operation(summary = "그룹별 활성 코드 개수", description = "특정 그룹의 활성화된 코드 개수를 조회합니다.")
+    @GetMapping("/common-codes/{groupId}/count/active")
+    public ResponseEntity<ApiResponse<Long>> getActiveCodeCountByGroup(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId){
+
+        long count = commonCodeService.countActiveByGroupId(groupId);
+        return ResponseEntity.ok(ApiResponse.success("활성 코드 개수 조회 성공", count));
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeGroupController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeGroupController.java
@@ -1,0 +1,119 @@
+package com.ocp.ocp_finalproject.admin.controller;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
+import com.ocp.ocp_finalproject.admin.dto.request.CommonCodeGroupRequest;
+import com.ocp.ocp_finalproject.admin.dto.response.CommonCodeGroupResponse;
+import com.ocp.ocp_finalproject.admin.service.CommonCodeGroupService;
+import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "공통코드 그룹")
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class CommonCodeGroupController {
+
+    private final CommonCodeGroupService commonCodeGroupService;
+
+    // 공통 코드 그룹 생성
+    @Operation(summary = "공통코드 그룹 생성", description = "새로운 공통코드 그룹을 생성합니다.")
+    @PostMapping("/common-codes/groups")
+    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> createGroup(
+            @Valid @RequestBody CommonCodeGroupRequest request){
+
+        CommonCodeGroup group = CommonCodeGroup.createBuilder()
+                .groupId(request.getGroupId())
+                .groupName(request.getGroupName())
+                .description(request.getDescription())
+                .codes(null)
+                .build();
+
+        CommonCodeGroup savedGroup = commonCodeGroupService.createGroup(group);
+        CommonCodeGroupResponse response = CommonCodeGroupResponse.fromWithoutCodes(savedGroup);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 생성 완료", response));
+    }
+
+
+    // 공통 코드 그룹 단건 조회
+    @Operation(summary = "공통코드 그룹 단건 조회", description = "그룹 ID로 공통코드 그룹을 조회합니다.")
+    @GetMapping("/common-codes/groups/{groupId}")
+    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> getGroup(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId){
+
+        CommonCodeGroup group = commonCodeGroupService.getGroup(groupId);
+        CommonCodeGroupResponse response = CommonCodeGroupResponse.fromWithoutCodes(group);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 조회 성공",response));
+    }
+
+    //공통코드 그룹 + 코드 조회 (N+1 방지)
+    @Operation(summary = "공통코드 그룹 + 코드 조회", description = "그룹과 포함된 코드를 함께 조회합니다.")
+    @GetMapping("/common-codes/groups/{groupId}/with-codes")
+    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> getGroupWithCodes(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId){
+
+        CommonCodeGroup group = commonCodeGroupService.getGroupWithCode(groupId);
+        CommonCodeGroupResponse response = CommonCodeGroupResponse.from(group);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹(코드 포함) 조회 성공", response));
+    }
+
+    //공통코드 그룹 목록 조회(페이징)
+    @Operation(summary = "공통코드 그룹 목록 조회", description = "모든 공통코드 그룹을 조회합니다. (페이징)")
+    @GetMapping("/common-codes/groups")
+    public ResponseEntity<ApiResponse<Page<CommonCodeGroupResponse>>> getAllGroups(
+            @ParameterObject Pageable pageable){
+
+        Page<CommonCodeGroup> groups = commonCodeGroupService.getGroups(pageable);
+        Page<CommonCodeGroupResponse> responses = groups.map(CommonCodeGroupResponse::fromWithoutCodes);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 목록 조회", responses));
+    }
+
+    //공통코드 그룹 검색
+    @Operation(summary = "공통코드 그룹 검색", description = "그룹 ID나 그룹명으로 검색합니다.")
+    @GetMapping("/common-codes/groups/search")
+    public ResponseEntity<ApiResponse<Page<CommonCodeGroupResponse>>> searchGroups(
+            @Parameter(description = "그룹 ID") @RequestParam(required = false) String groupId,
+            @Parameter(description = "그룹명") @RequestParam(required = false) String groupName,
+            @ParameterObject Pageable pageable){
+
+        Page<CommonCodeGroup> groups = commonCodeGroupService.searchGroups(groupId, groupName, pageable);
+        Page<CommonCodeGroupResponse> responses = groups.map(CommonCodeGroupResponse::fromWithoutCodes);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 검색 완료", responses));
+    }
+
+    // 공통코드 그룹 정보 수정
+    @Operation(summary = "공통코드 그룹 수정", description = "공통코드 그룹 정보를 수정합니다.")
+    @PutMapping("/common-codes/groups/{groupId}")
+    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> updateGroup(
+            @Parameter(description = "그룹 ID") @PathVariable String groupId,
+            @Valid @RequestBody  CommonCodeGroupRequest request){
+
+        commonCodeGroupService.updateGroup(
+                groupId,
+                request.getGroupName(),
+                request.getDescription()
+        );
+
+        CommonCodeGroup updateGroup = commonCodeGroupService.getGroup(groupId);
+        CommonCodeGroupResponse response = CommonCodeGroupResponse.fromWithoutCodes(updateGroup);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 수정 완료", response));
+    }
+
+    //공통코드 그룹 삭제
+    @Operation(summary = "공통코드 그룹 삭제", description = "공통코드 그룹을 삭제합니다. (포함된 코드도 함께 삭제)")
+    @DeleteMapping("/common-codes/groups/{groupId}")
+    public ResponseEntity<ApiResponse<Void>> deleteGroup(
+            @PathVariable String groupId){
+
+        commonCodeGroupService.deleteGroup(groupId);
+        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 삭제 완료"));
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/domain/CommonCode.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/domain/CommonCode.java
@@ -62,4 +62,29 @@ public class CommonCode extends BaseEntity {
             group.getCommonCodes().add(this);
         }
     }
+
+    // 비즈니스 메서드 작성
+    /**
+     * 활성화 상태 변경
+     */
+    public void updateActive(Boolean isActive)
+    {
+        this.isActive = isActive;
+    }
+
+    /**
+     * 코드 정보를 한번에 수정
+     */
+    public void updateInfo(String codeName, String description, Integer sortOrder)
+    {
+        this.codeName = codeName;
+        this.description = description;
+        this.sortOrder = sortOrder;
+    }
+    /*
+    엔티티에 비즈니스 로직을 넣는 이유는:
+    1. 캡슐화: 데이터 변경 로직을 엔티티 내부에 숨김
+    2. 의도 표현: setIsActive(false) 보다 updateActive(false)가 더 명확
+    3. 유지보수성: 변경 로직이 한곳에 모여있어 수정이 쉬움
+    4. 확장성: 나중에 로직 추가 시 메서드만 수정하면 됨*/
 }

--- a/src/main/java/com/ocp/ocp_finalproject/admin/domain/CommonCodeGroup.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/domain/CommonCodeGroup.java
@@ -60,4 +60,11 @@ public class CommonCodeGroup extends BaseEntity {
         }
         code.setCommonCodeGroup(this);
     }
+
+    // 비즈니스 메서드 작성
+    // 그룹 정보 수정
+    public void updateInfo(String groupName, String description) {
+        this.groupName = groupName;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/request/CommonCodeGroupRequest.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/request/CommonCodeGroupRequest.java
@@ -1,0 +1,30 @@
+package com.ocp.ocp_finalproject.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonCodeGroupRequest {
+
+    @Schema(description = "코드 그룹 ID", example = "USER_STATUS")
+    @NotBlank(message = "코드 그룹 ID는 필수입니다.")
+    @Size(max = 50, message = "코드 그룹 ID는 50자를 초과할 수 없습니다.")
+    private String groupId;
+
+    @Schema(description = "코드 그룹명", example = "사용자 상태")
+    @NotBlank(message = "코드 그룹명은 필수입니다.")
+    @Size(max = 100, message = "코드 그룹명은 100자를 초과할 수 없습니다.")
+    private String groupName;
+
+    @Schema(description = "설명", example = "사용자 계정의 상태를 나타내는 코드 그룹")
+    @Size(max = 255, message = "설명은 255자를 초과할 수 없습니다.")
+    private String description;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/request/CommonCodeRequest.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/request/CommonCodeRequest.java
@@ -1,0 +1,43 @@
+package com.ocp.ocp_finalproject.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonCodeRequest {
+
+    @Schema(description = "코드 ID", example = "ACTIVE")
+    @NotBlank(message = "코드 ID는 필수입니다.")
+    @Size(max = 50, message = "코드 ID는 50자를 초과할 수 없습니다.")
+    private String codeId;
+
+    @Schema(description = "코드 그룹 ID", example = "USER_STATUS")
+    @NotBlank(message = "코드 그룹 ID는 필수입니다.")
+    @Size(max = 50, message = "코드 그룹 ID는 50자를 초과할 수 없습니다.")
+    private String groupId;
+
+    @Schema(description = "코드명", example = "활성")
+    @NotBlank(message = "코드 명은 필수입니다.")
+    @Size(max = 100, message = "코드명은 100자를 초과할 수 없습니다.")
+    private String codeName;
+
+    @Schema(description = "설명", example = "정상적으로 활동 중인 사용자")
+    @Size(max = 255, message = "설명은 255자를 초과할 수 없습니다.")
+    private String description;
+
+    @Schema(description = "정렬 순서", example = "1")
+    private Integer sortOrder;
+
+    @Schema(description = "활성화 여부", example = "true")
+    @NotNull(message = "활성화 여부는 필수입니다.")
+    private Boolean isActive;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/CommonCodeGroupResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/CommonCodeGroupResponse.java
@@ -1,0 +1,65 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonCodeGroupResponse {
+    @Schema(description = "코드 그룹 ID", example = "USER_STATUS")
+    private String groupId;
+
+    @Schema(description = "코드 그룹명", example = "사용자 상태")
+    private String groupName;
+
+    @Schema(description = "설명", example = "사용자 계정의 상태를 나타내는 코드 그룹")
+    private String description;
+
+    @Schema(description = "생성일시", example = "2025-12-03T10:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2025-12-03T10:00:00")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "포함된 공통코드 목록")
+    private List<CommonCodeResponse> commonCodes;
+
+    public static CommonCodeGroupResponse from(CommonCodeGroup group) {
+        return CommonCodeGroupResponse.builder()
+                .groupId(group.getId())
+                .groupName(group.getGroupName())
+                .description(group.getDescription())
+                .createdAt(group.getCreatedAt())
+                .updatedAt(group.getUpdatedAt())
+                .commonCodes(group.getCommonCodes().stream()
+                        .map(CommonCodeResponse::from)
+                        .collect(Collectors.toList()))
+                .build();
+
+                /*   <stream을 for문으로 작성한다면?>
+                 *   List<CommonCodeResponse> responses = new ArrayList<>();
+                 *   for (CommonCode code : group.getCommonCodes()) {
+                 *       responses.add(CommonCodeResponse.from(code));
+                 *       }
+                 */
+    }
+    public static CommonCodeGroupResponse fromWithoutCodes(CommonCodeGroup group) {
+        return CommonCodeGroupResponse.builder()
+                .groupId(group.getId())
+                .groupName(group.getGroupName())
+                .description(group.getDescription())
+                .createdAt(group.getCreatedAt())
+                .updatedAt(group.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/CommonCodeResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/CommonCodeResponse.java
@@ -1,0 +1,53 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonCodeResponse {
+    @Schema(description = "코드 ID", example = "ACTIVE")
+    private String codeId;
+
+    @Schema(description = "코드 그룹 ID", example = "USER_STATUS")
+    private String groupId;
+
+    @Schema(description = "코드명", example = "활성")
+    private String codeName;
+
+    @Schema(description = "설명", example = "정상적으로 활동 중인 사용자")
+    private String description;
+
+    @Schema(description = "정렬 순서", example = "1")
+    private Integer sortOrder;
+
+    @Schema(description = "활성화 여부", example = "true")
+    private Boolean isActive;
+
+    @Schema(description = "생성일시", example = "2025-12-03T10:00:00")
+    private LocalDateTime createAt;
+
+    @Schema(description = "수정일시", example = "2025-12-03T10:00:00")
+    private LocalDateTime updateAt;
+
+    public static CommonCodeResponse from(CommonCode commonCode) {
+        return CommonCodeResponse.builder()
+                .codeId(commonCode.getId())
+                .groupId(commonCode.getCommonCodeGroup().getId())
+                .codeName(commonCode.getCodeName())
+                .description(commonCode.getDescription())
+                .sortOrder(commonCode.getSortOrder())
+                .isActive(commonCode.getIsActive())
+                .createAt(commonCode.getCreatedAt())
+                .updateAt(commonCode.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/repository/CommonCodeGroupRepository.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/repository/CommonCodeGroupRepository.java
@@ -1,0 +1,47 @@
+package com.ocp.ocp_finalproject.admin.repository;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CommonCodeGroupRepository extends JpaRepository<CommonCodeGroup, String> {
+
+    /*
+    * 그룹명으로 검색 (페이징)
+    * @param groupName 그룹명
+    * @param pageable 페이징 정보
+    * @return 그룹 목록
+    * */
+    Page<CommonCodeGroup> findByGroupNameContaining(String groupName, Pageable pageable);
+
+    /*
+    * 그룹 ID 또는 그룹명으로 검색
+    * @param groupId 그룹 ID
+    * @param groupName 그룹명
+    * @param pageable 페이징 정보
+    * @return 그룹 목록
+    * */
+    @Query("SELECT g FROM CommonCodeGroup g WHERE "+
+            "(:groupId IS NULL OR g.id LIKE %:groupId%) AND " +
+            "(:groupName IS NULL or g.groupName LIKE %:groupName%)")
+    Page<CommonCodeGroup> searchGroup(
+            @Param("groupId") String groupId,
+            @Param("groupName") String groupName,
+            Pageable pageable
+    );
+
+    /*
+    * 코드 포함 그룹 조회 (N+1 방지)
+    * @param groupId 그룹 ID
+    * @return 공통코드 그룹
+    * */
+    @Query("SELECT g FROM CommonCodeGroup g " +
+            "LEFT JOIN FETCH g.commonCodes " +
+            "WHERE g.id = :groupId")
+    Optional<CommonCodeGroup> findByIdWithCodes(@Param("groupId") String groupId);
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/repository/CommonCodeRepository.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/repository/CommonCodeRepository.java
@@ -1,0 +1,97 @@
+package com.ocp.ocp_finalproject.admin.repository;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+
+public interface CommonCodeRepository extends JpaRepository<CommonCode, String> {
+
+    /*
+    * 그룹 ID로 코드 목록 조회
+    * @Param groupId 그룹 ID
+    * @return 코드 목록
+    * */
+
+    @Query("SELECT c FROM CommonCode c WHERE c.commonCodeGroup.id= :groupId ORDER BY c.sortOrder ASC")
+    List<CommonCode> findByGroupId(@Param("groupId") String groupId);
+
+    /*
+    * 그룹 ID로 코드 목록 조회 (페이징)
+    * @Param groupId 그룹 ID
+    * @Param pageable 페이징 정보
+    * @return 코드 목록
+    * */
+    @Query("SELECT c FROM CommonCode c WHERE c.commonCodeGroup.id = :groupId")
+    Page<CommonCode> findByGroupIdPaged(@Param("groupId") String groupId, Pageable pageable);
+
+
+    /*
+    * 활성화된 코드만 조회
+    * @Param groupId 그룹 ID
+    * @return 활성 코드 목록
+    * */
+    @Query("SELECT c FROM CommonCode c " +
+            "WHERE c.commonCodeGroup.id = :groupId " +
+            "AND c.isActive = true " +
+            "ORDER BY c.sortOrder ASC")
+    List<CommonCode> findActiveCodesByGroupId(@Param("groupId") String groupId);
+
+    /*
+    * 코드명으로 검색
+    * @Param CodeName 코드명
+    * @return 코드 목록
+    * */
+    Page<CommonCode> findByCodeNameContaining(String codeName, Pageable pageable);
+
+    /*
+    * 활성화 상태로 필터링
+    * @Param isActive 활성화 여부
+    * @Param Pageable 페이징 정보
+    * @return 코드 목록
+    * */
+    Page<CommonCode> findByIsActive(Boolean isActive, Pageable pageable);
+
+    /*
+    * 복합 검색 (그룹, 코드명, 활성화 상태)
+    * @Param groupId 그룹 ID
+    * @Param codeName 코드명
+    * @Param isActive 활성화 여부
+    * @Param pageable 페이징 정보
+    * return 코드 목록
+    * */
+    @Query("SELECT c FROM CommonCode c WHERE " +
+            "(:groupId IS NULL OR c.commonCodeGroup.id = :groupId) AND " +
+            "(:codeName IS NULL OR c.codeName LIKE %:codeName%) AND " +
+            "(:isActive IS NULL OR c.isActive = :isActive)")
+    Page<CommonCode> searchCodes(
+            @Param("groupId") String groupId,
+            @Param("codeName") String codeName,
+            @Param("isActive") Boolean isActive,
+            Pageable pageable
+    );
+    /*
+    * 그룹별 코드 개수
+    * @param groupId 그룹 ID
+    * @return 코드 개수
+    * */
+    @Query("SELECT COUNT(c) FROM CommonCode c WHERE " +
+            "c.commonCodeGroup.id = :groupId")
+    long countByGroupId(@Param("groupId") String groupId);
+
+    /*
+    * 활성화된 코드 개수
+    * @param groupId 그룹 ID
+    * @return 활성 코드 개수
+    */
+    @Query("SELECT COUNT(c) FROM CommonCode c WHERE " +
+            "c.commonCodeGroup.id = :groupId AND " +
+            "c.isActive = true")
+    long countActiveByGroupId(@Param("groupId") String groupId);
+
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/service/CommonCodeGroupService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/service/CommonCodeGroupService.java
@@ -1,0 +1,105 @@
+package com.ocp.ocp_finalproject.admin.service;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
+import com.ocp.ocp_finalproject.admin.repository.CommonCodeGroupRepository;
+import com.ocp.ocp_finalproject.common.exception.CustomException;
+import com.ocp.ocp_finalproject.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly=true)
+public class CommonCodeGroupService {
+    private final CommonCodeGroupRepository commonCodeGroupRepository;
+
+    /*
+    * 그룹 생성
+    * @Param group 공통코드 그룹
+    * @return 생성된 그룹
+    * */
+    @Transactional
+    public CommonCodeGroup createGroup(CommonCodeGroup group){
+        // 그룹 ID 중복 체크
+        if(commonCodeGroupRepository.existsById(group.getId())){
+            throw new CustomException(ErrorCode.DUPLICATE_COMMON_CODE);
+        }
+        return commonCodeGroupRepository.save(group);
+    }
+
+    /*
+    * 그룹 단건 조회
+    * @Param groupId 그룹 ID
+    * @return 공통코드 그룹
+    * */
+    public CommonCodeGroup getGroup(String groupId){
+        return commonCodeGroupRepository.findById(groupId)
+                .orElseThrow(()-> new CustomException(ErrorCode.COMMON_CODE_GROUP_NOT_FOUND));
+    }
+
+    /*
+    * 그룹 목록 조회(페이징)
+    * @Param pageable 페이징 정보
+    * @return 그룹 목록
+    * */
+    public Page<CommonCodeGroup> getGroups(Pageable pageable){
+        return commonCodeGroupRepository.findAll(pageable);
+    }
+
+    /*
+    * 그룹 검색
+    * @Param groupId 그룹 ID (선택)
+    * @Param groupName 그룹명 (선택)
+    * @Param pageable 페이징 정보
+    * @return 그룹 목록
+    * */
+    public Page<CommonCodeGroup> searchGroups(String groupId, String groupName, Pageable pageable){
+        return commonCodeGroupRepository.searchGroup(groupId, groupName, pageable);
+    }
+
+    /*
+    * 그룹명으로 검색
+    * @Param groupName 그룹명
+    * @Param pageable 페이징 정보
+    * @return 그룹 목록
+    * */
+    public Page<CommonCodeGroup> searchByGroups(String groupName, Pageable pageable){
+        return commonCodeGroupRepository.findByGroupNameContaining(groupName, pageable);
+    }
+
+    /*
+    * 코드 포함 그룹 조회(N+1 방지)
+    * @Param groupId 그룹 ID
+    * @return 공통코드 그룹 (코드 포함)
+    * */
+    public CommonCodeGroup getGroupWithCode(String groupId){
+        return commonCodeGroupRepository.findByIdWithCodes(groupId)
+                .orElseThrow(()-> new CustomException(ErrorCode.COMMON_CODE_GROUP_NOT_FOUND));
+    }
+
+    /*
+    * 그룹 정보 수정
+    * @Param groupId 그룹 ID
+    * @Param groupName 그룹명
+    * @Param description 설명
+    * */
+    @Transactional
+    public void updateGroup(String groupId, String groupName, String description){
+        CommonCodeGroup group = getGroup(groupId);
+        group.updateInfo(groupName, description);
+    }
+
+    /*
+    * 그룹 삭제
+    * @Param groupId 그룹 ID
+    * */
+    @Transactional
+    public void deleteGroup(String groupId){
+        CommonCodeGroup group = getGroup(groupId);
+        commonCodeGroupRepository.delete(group);
+    }
+
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/service/CommonCodeService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/service/CommonCodeService.java
@@ -1,0 +1,157 @@
+package com.ocp.ocp_finalproject.admin.service;
+
+import com.ocp.ocp_finalproject.admin.domain.CommonCode;
+import com.ocp.ocp_finalproject.admin.repository.CommonCodeRepository;
+import com.ocp.ocp_finalproject.common.exception.CustomException;
+import com.ocp.ocp_finalproject.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommonCodeService {
+    private final CommonCodeRepository commonCodeRepository;
+
+    /*
+     * 코드 생성
+     * @Param code 공통코드
+     * @return 생성된 코드
+     * */
+    @Transactional
+    public CommonCode createCode(CommonCode code) {
+        // 코드 ID 중복 체크
+        if (commonCodeRepository.existsById(code.getId())) {
+            throw new CustomException(ErrorCode.DUPLICATE_COMMON_CODE);
+        }
+        return commonCodeRepository.save(code);
+    }
+
+    /*
+     * 코드 단건 조회
+     * @Param codeId 코드 ID
+     * @return 공통코드
+     * */
+    public CommonCode getCode(String codeId) {
+        return commonCodeRepository.findById(codeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMON_CODE_NOT_FOUND));
+    }
+
+    /*
+     * 그룹 ID로 코드 목록 조회
+     * @Param groupId 그룹 ID
+     * @return 코드 목록 (정렬됨)
+     * */
+    public List<CommonCode> getCodesByGroupId(String groupId) {
+        return commonCodeRepository.findByGroupId(groupId);
+    }
+
+    /*
+     * 그룹 ID로 코드 목록 조회 (페이징)
+     * @Param groupId 그룹 ID
+     * @Param pageable 페이징 정보
+     * @return 코드 목록
+     * */
+    public Page<CommonCode> getCodesByGroupIdPaged(String groupId, Pageable pageable) {
+        return commonCodeRepository.findByGroupIdPaged(groupId, pageable);
+    }
+
+    /*
+     * 활성화된 코드만 조회
+     * @Param groupId 그룹 ID
+     * @return 활성 코드 목록
+     * */
+    public List<CommonCode> getActiveCodesByGroupId(String groupId) {
+        return commonCodeRepository.findActiveCodesByGroupId(groupId);
+    }
+
+    /*
+    * 코드명으로 검색
+    * @Param codeName 코드명
+    * @Param pageable 페이징 정보
+    * @return 코드 목록
+    * */
+    public Page<CommonCode> searchByCodeName(String codeName, Pageable pageable) {
+        return commonCodeRepository.findByCodeNameContaining(codeName, pageable);
+    }
+
+    /*
+    * 활성화 상태로 필터링
+    * @Param isActive 활성화 여부
+    * @Param pageable 페이징 정보
+    * @return 코드 목록
+    * */
+    public Page<CommonCode> getCodeByActiveStatus(Boolean isActive, Pageable pageable) {
+        return commonCodeRepository.findByIsActive(isActive, pageable);
+    }
+
+    /*
+    * @Param groupId 그룹 ID (선택)
+    * @Param codeName 코드명 (선택)
+    * @Param isActive 활성화 여부 (선택)
+    * @Param pageable 페이징 정보
+    * @return 코드 목록
+    * */
+    public Page<CommonCode> searchCodes(String groupId, String codeName, Boolean isActive, Pageable pageable){
+        return commonCodeRepository.searchCodes(groupId, codeName, isActive, pageable);
+    }
+
+    /*
+    * 그룹별 코드 개수
+    * @Param groupId 그룹 ID
+    * @return 코드 개수
+    * */
+    public long countByGroupId(String groupId) {
+        return commonCodeRepository.countByGroupId(groupId);
+    }
+
+    /*
+    * 활성화된 코드 개수
+    * @Param groupdId 그룹 ID
+    * @return 활성 코드 개수
+    * */
+    public long countActiveByGroupId(String groupId) {
+        return commonCodeRepository.countActiveByGroupId(groupId);
+    }
+
+    /*
+    * 코드 비활성화
+    * @Param codeId 코드 ID
+    * */
+    @Transactional
+    public void deactivateCode(String codeId)
+    {
+        CommonCode code = getCode(codeId);
+        code.updateActive(false);
+    }
+
+    /*
+    * 코드 활성화
+    * @Param codeId 코드 ID
+    * */
+    @Transactional
+    public void activateCode(String codeId)
+    {
+        CommonCode code = getCode(codeId);
+        code.updateActive(true);
+    }
+
+    /*
+    * 코드 정보 수정
+    * @Param codeId 코드 ID
+    * @Param codeName 코드명
+    * @Param description 설명
+    * @Param sortOrder 정렬 순서
+    * */
+    @Transactional
+    public void updateCode(String codeId, String codeName, String description, Integer sortOrder)
+    {
+        CommonCode code = getCode(codeId);
+        code.updateInfo(codeName, description, sortOrder);
+    }
+}


### PR DESCRIPTION
  - 공통코드 그룹 CRUD API 구현
    - 생성, 조회(단건/목록/with-codes), 검색, 수정, 삭제

  - 공통코드 CRUD API 구현
    - 생성, 조회(단건/그룹별), 검색, 수정
    - 활성화/비활성화 기능
    - 그룹별 코드 개수 조회

  - N+1 문제 해결
    - fetch join을 통한 코드 포함 조회 최적화

  - 검색 기능
    - 공통코드 그룹: groupId, groupName LIKE 검색
    - 공통코드: groupId, codeName, isActive 복합 검색

  - Swagger 문서화
    - Request/Response DTO에 @Schema 적용
    - 모든 필드에 description 및 example 추가

## 📁 관련 이슈
#이슈번호  21

## 🔥 작업 내용
  - 공통코드 그룹 CRUD API 구현
    - 생성, 조회(단건/목록/with-codes), 검색, 수정, 삭제

  - 공통코드 CRUD API 구현
    - 생성, 조회(단건/그룹별), 검색, 수정
    - 활성화/비활성화 기능
    - 그룹별 코드 개수 조회

  - N+1 문제 해결
    - fetch join을 통한 코드 포함 조회 최적화

  - 검색 기능
    - 공통코드 그룹: groupId, groupName LIKE 검색
    - 공통코드: groupId, codeName, isActive 복합 검색

  - Swagger 문서화
    - Request/Response DTO에 @Schema 적용
    - 모든 필드에 description 및 example 추가

## 🧪 테스트 결과
<img width="1570" height="749" alt="image" src="https://github.com/user-attachments/assets/a31596e4-0e6d-4bb5-9699-ab2e9d1725d6" />
<img width="1575" height="501" alt="image" src="https://github.com/user-attachments/assets/f4863e18-6e19-4c97-b31e-b271ab853126" />



## 📌 추가 확인 사항 (Optional)
