### PR TITLE
refactor: Spring Boot 버전 및 의존성 호환성 수정 (#54)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.0'
+    id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -25,18 +25,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/ocp/ocp_finalproject/common/response/ApiResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/common/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.ocp.ocp_finalproject.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,13 +8,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ApiResponse<T> {
 
-    //성공 여부(true/false)
+    @Schema(description = "성공 여부", example = "true")
     private boolean success;
 
-    //message: 응답 메시지 (예: "조회 성공", "등록 완료")
+    @Schema(description = "응답 메시지", example = "요청이 성공적으로 처리되었습니다")
     private String message;
 
-    //조회 결과, 생성된 객체 등 다양한 타입의 데이터를 담을 수 있음
+    @Schema(description = "응답 데이터")
     private T data;
 
     //성공 응답 (데이터 O)

--- a/src/main/java/com/ocp/ocp_finalproject/config/RabbitConfig.java
+++ b/src/main/java/com/ocp/ocp_finalproject/config/RabbitConfig.java
@@ -3,7 +3,7 @@ package com.ocp.ocp_finalproject.config;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,13 +34,13 @@ public class RabbitConfig {
     }
 
     @Bean
-    public JacksonJsonMessageConverter messageConverter() {
-        return new JacksonJsonMessageConverter();
+    public Jackson2JsonMessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
-                                         JacksonJsonMessageConverter messageConverter) {
+                                         Jackson2JsonMessageConverter messageConverter) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(messageConverter);
         return rabbitTemplate;


### PR DESCRIPTION
## 📁 관련 이슈
#이슈번호  54

## 🔥 작업 내용
  - Spring Boot 버전 다운그레이드 (4.0.0 → 3.3.5)
    - Spring Boot 4.0과 SpringDoc 호환성 문제 해결

  - SpringDoc 버전 업그레이드 (2.3.0 → 2.6.0)
    - Spring Boot 3.3.5 호환 버전으로 변경

  - 존재하지 않는 의존성 제거
    - spring-boot-starter-webmvc 제거
    - spring-boot-starter-data-jpa-test 제거
    - spring-boot-starter-webmvc-test 제거

  - RabbitMQ MessageConverter 수정
    - JacksonJsonMessageConverter → Jackson2JsonMessageConverter

  - Swagger 문서화 개선
    - ApiResponse에 @Schema 추가## 🧪 테스트 결과
    
로컬 실행 여부 / 필요한 경우 스크린샷 첨부

swagger 화면 출력 O 
