### PR TITLE
refactor: ApiResponse를 ApiResult로 변경하여 Swagger 충돌 해결 (#67)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeController.java
@@ -6,7 +6,7 @@ import com.ocp.ocp_finalproject.admin.dto.request.CommonCodeRequest;
 import com.ocp.ocp_finalproject.admin.dto.response.CommonCodeResponse;
 import com.ocp.ocp_finalproject.admin.service.CommonCodeGroupService;
 import com.ocp.ocp_finalproject.admin.service.CommonCodeService;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,7 +33,7 @@ public class CommonCodeController {
     // 공통 코드 생성
     @Operation(summary = "공통코드 생성", description = "새로운 공통코드를 생성합니다.")
     @PostMapping("/common-codes")
-    public ResponseEntity<ApiResponse<CommonCodeResponse>> createCode(
+    public ResponseEntity<ApiResult<CommonCodeResponse>> createCode(
             @Valid @RequestBody CommonCodeRequest request){
 
         // 그룹 조회
@@ -51,50 +51,50 @@ public class CommonCodeController {
 
         CommonCode saveCode = commonCodeService.createCode(code);
         CommonCodeResponse response = CommonCodeResponse.from(saveCode);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 생성 완료", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 생성 완료", response));
     }
 
     // 공통 코드 단건 조회
     @Operation(summary = "공통코드 단건 조회", description = "그룹 ID와 코드 ID로 공통코드를 조회합니다.")
     @GetMapping("/common-codes/{groupId}/{codeId}")
-    public ResponseEntity<ApiResponse<CommonCodeResponse>> getCode(
+    public ResponseEntity<ApiResult<CommonCodeResponse>> getCode(
             @Parameter(description = "그룹 ID") @PathVariable String groupId,
             @Parameter(description = "코드 ID") @PathVariable String codeId){
 
         CommonCode code = commonCodeService.getCode(codeId);
         CommonCodeResponse response = CommonCodeResponse.from(code);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 조회 성공", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 조회 성공", response));
     }
 
     // 그룹별 코드 목록 조회(리스트)
     @Operation(summary = "그룹별 코드 목록 조회", description = "특정 그룹의 모든 코드를 정렬 순서대로 조회합니다.")
     @GetMapping("/common-codes/{groupId}")
-    public ResponseEntity<ApiResponse<List<CommonCodeResponse>>> getCodesByGroup(
+    public ResponseEntity<ApiResult<List<CommonCodeResponse>>> getCodesByGroup(
             @Parameter(description = "그룹 ID") @PathVariable String groupId){
 
         List<CommonCode> codes = commonCodeService.getCodesByGroupId(groupId);
         List<CommonCodeResponse> response = codes.stream()
                 .map(CommonCodeResponse::from)
                 .collect(Collectors.toList());
-        return ResponseEntity.ok(ApiResponse.success("그룹별 코드 목록 조회 성공", response));
+        return ResponseEntity.ok(ApiResult.success("그룹별 코드 목록 조회 성공", response));
     }
 
     // 그룹별 코드 목록 조회 (페이징)
     @Operation(summary = "그룹별 코드 목록 조회(페이징)", description = "특정 그룹의 코드를 페이징하여 조회합니다.")
     @GetMapping("/common-codes/{groupId}/paged")
-    public ResponseEntity<ApiResponse<Page<CommonCodeResponse>>> getPagedCode(
+    public ResponseEntity<ApiResult<Page<CommonCodeResponse>>> getPagedCode(
             @Parameter(description = "그룹 ID") @PathVariable String groupId,
             @ParameterObject Pageable pageable){
 
         Page<CommonCode> codes = commonCodeService.getCodesByGroupIdPaged(groupId, pageable);
         Page<CommonCodeResponse> responses = codes.map(CommonCodeResponse::from);
-        return ResponseEntity.ok(ApiResponse.success("그룹별 코드 목록 조회 성공", responses));
+        return ResponseEntity.ok(ApiResult.success("그룹별 코드 목록 조회 성공", responses));
     }
 
     // 활성화된 코드만 조회
     @Operation(summary = "활성화된 코드 조회", description = "특정 그룹의 활성화된 코드만 조회합니다.")
     @GetMapping("/common-codes/{groupId}/active")
-    public ResponseEntity<ApiResponse<List<CommonCodeResponse>>> getActiveCodesByGroup(
+    public ResponseEntity<ApiResult<List<CommonCodeResponse>>> getActiveCodesByGroup(
             @Parameter(description = "그룹 ID") @PathVariable String groupId){
 
         List<CommonCode> codes = commonCodeService.getActiveCodesByGroupId(groupId);
@@ -102,13 +102,13 @@ public class CommonCodeController {
                 .map(CommonCodeResponse::from)
                 .collect(Collectors.toList());
 
-        return ResponseEntity.ok(ApiResponse.success("활성 코드 목록 조회 성공", responses));
+        return ResponseEntity.ok(ApiResult.success("활성 코드 목록 조회 성공", responses));
     }
 
     // 공통코드 검색
     @Operation(summary = "공통코드 검색", description = "그룹, 코드명, 활성화 상태로 검색합니다.")
     @GetMapping("/common-codes/search")
-    public ResponseEntity<ApiResponse<Page<CommonCodeResponse>>> searchCode(
+    public ResponseEntity<ApiResult<Page<CommonCodeResponse>>> searchCode(
             @Parameter(description = "그룹 ID") @RequestParam(required = false) String groupId,
             @Parameter(description = "코드명") @RequestParam(required = false) String codeName,
             @Parameter(description = "활성화 여부") @RequestParam(required = false) Boolean isActive,
@@ -116,13 +116,13 @@ public class CommonCodeController {
 
             Page<CommonCode> codes = commonCodeService.searchCodes(groupId, codeName, isActive, pageable);
             Page<CommonCodeResponse> responses = codes.map(CommonCodeResponse::from);
-            return ResponseEntity.ok(ApiResponse.success("공통코드 검색 완료", responses));
+            return ResponseEntity.ok(ApiResult.success("공통코드 검색 완료", responses));
     }
 
     // 코드 정보 수정
     @Operation(summary = "공통코드 수정", description = "공통코드 정보를 수정합니다.")
     @PutMapping("/common-codes/{groupId}/{codeId}")
-    public ResponseEntity<ApiResponse<CommonCodeResponse>> updateCode(
+    public ResponseEntity<ApiResult<CommonCodeResponse>> updateCode(
             @Parameter(description = "그룹 ID") @PathVariable String groupId,
             @Parameter(description = "코드 ID") @PathVariable String codeId,
             @Valid @RequestBody CommonCodeRequest request){
@@ -136,52 +136,52 @@ public class CommonCodeController {
 
         CommonCode updateCode = commonCodeService.getCode(codeId);
         CommonCodeResponse response = CommonCodeResponse.from(updateCode);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 수정 완료", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 수정 완료", response));
     }
 
     // 코드 활성화
     @Operation(summary = "공통코드 활성화", description = "공통코드를 활성화합니다.")
     @PatchMapping("/common-codes/{groupId}/{codeId}/activate")
-    public ResponseEntity<ApiResponse<CommonCodeResponse>> activateCode(
+    public ResponseEntity<ApiResult<CommonCodeResponse>> activateCode(
             @Parameter(description = "그룹 ID") @PathVariable String groupId,
             @Parameter(description = "코드 ID")  @PathVariable String codeId){
 
         commonCodeService.activateCode(codeId);
         CommonCode code = commonCodeService.getCode(codeId);
         CommonCodeResponse response = CommonCodeResponse.from(code);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 활성화 완료", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 활성화 완료", response));
     }
 
     // 코드 비활성화
     @Operation(summary = "공통코드 비활성화", description = "공통코드를 비활성화합니다.")
     @PatchMapping("/common-codes/{groupId}/{codeId}/deactivate")
-    public ResponseEntity<ApiResponse<CommonCodeResponse>> deactivateCode(
+    public ResponseEntity<ApiResult<CommonCodeResponse>> deactivateCode(
             @Parameter(description = "그룹 ID") @PathVariable String groupId,
             @Parameter(description = "코드 ID") @PathVariable String codeId){
 
         commonCodeService.deactivateCode(codeId);
         CommonCode code = commonCodeService.getCode(codeId);
         CommonCodeResponse response = CommonCodeResponse.from(code);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 비활성화 완료", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 비활성화 완료", response));
     }
 
     // 그룹별 코드 개수 조회
     @Operation(summary = "그룹별 코드 개수", description = "특정 그룹의 전체 코드 개수를 조회합니다.")
     @GetMapping("/common-codes/{groupId}/count")
-    public ResponseEntity<ApiResponse<Long>> getCodeCountByGroup(
+    public ResponseEntity<ApiResult<Long>> getCodeCountByGroup(
             @Parameter(description = "그룹 ID") @PathVariable String groupId){
 
         long count = commonCodeService.countByGroupId(groupId);
-        return ResponseEntity.ok(ApiResponse.success("코드 개수 조회 성공", count));
+        return ResponseEntity.ok(ApiResult.success("코드 개수 조회 성공", count));
     }
 
     // 그룹별 활성 코드 개수 조회
     @Operation(summary = "그룹별 활성 코드 개수", description = "특정 그룹의 활성화된 코드 개수를 조회합니다.")
     @GetMapping("/common-codes/{groupId}/count/active")
-    public ResponseEntity<ApiResponse<Long>> getActiveCodeCountByGroup(
+    public ResponseEntity<ApiResult<Long>> getActiveCodeCountByGroup(
             @Parameter(description = "그룹 ID") @PathVariable String groupId){
 
         long count = commonCodeService.countActiveByGroupId(groupId);
-        return ResponseEntity.ok(ApiResponse.success("활성 코드 개수 조회 성공", count));
+        return ResponseEntity.ok(ApiResult.success("활성 코드 개수 조회 성공", count));
     }
 }

--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeGroupController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeGroupController.java
@@ -4,7 +4,7 @@ import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
 import com.ocp.ocp_finalproject.admin.dto.request.CommonCodeGroupRequest;
 import com.ocp.ocp_finalproject.admin.dto.response.CommonCodeGroupResponse;
 import com.ocp.ocp_finalproject.admin.service.CommonCodeGroupService;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,7 +27,7 @@ public class CommonCodeGroupController {
     // 공통 코드 그룹 생성
     @Operation(summary = "공통코드 그룹 생성", description = "새로운 공통코드 그룹을 생성합니다.")
     @PostMapping("/common-codes/groups")
-    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> createGroup(
+    public ResponseEntity<ApiResult<CommonCodeGroupResponse>> createGroup(
             @Valid @RequestBody CommonCodeGroupRequest request){
 
         CommonCodeGroup group = CommonCodeGroup.createBuilder()
@@ -39,60 +39,60 @@ public class CommonCodeGroupController {
 
         CommonCodeGroup savedGroup = commonCodeGroupService.createGroup(group);
         CommonCodeGroupResponse response = CommonCodeGroupResponse.fromWithoutCodes(savedGroup);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 생성 완료", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹 생성 완료", response));
     }
 
 
     // 공통 코드 그룹 단건 조회
     @Operation(summary = "공통코드 그룹 단건 조회", description = "그룹 ID로 공통코드 그룹을 조회합니다.")
     @GetMapping("/common-codes/groups/{groupId}")
-    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> getGroup(
+    public ResponseEntity<ApiResult<CommonCodeGroupResponse>> getGroup(
             @Parameter(description = "그룹 ID") @PathVariable String groupId){
 
         CommonCodeGroup group = commonCodeGroupService.getGroup(groupId);
         CommonCodeGroupResponse response = CommonCodeGroupResponse.fromWithoutCodes(group);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 조회 성공",response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹 조회 성공",response));
     }
 
     //공통코드 그룹 + 코드 조회 (N+1 방지)
     @Operation(summary = "공통코드 그룹 + 코드 조회", description = "그룹과 포함된 코드를 함께 조회합니다.")
     @GetMapping("/common-codes/groups/{groupId}/with-codes")
-    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> getGroupWithCodes(
+    public ResponseEntity<ApiResult<CommonCodeGroupResponse>> getGroupWithCodes(
             @Parameter(description = "그룹 ID") @PathVariable String groupId){
 
         CommonCodeGroup group = commonCodeGroupService.getGroupWithCode(groupId);
         CommonCodeGroupResponse response = CommonCodeGroupResponse.from(group);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹(코드 포함) 조회 성공", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹(코드 포함) 조회 성공", response));
     }
 
     //공통코드 그룹 목록 조회(페이징)
     @Operation(summary = "공통코드 그룹 목록 조회", description = "모든 공통코드 그룹을 조회합니다. (페이징)")
     @GetMapping("/common-codes/groups")
-    public ResponseEntity<ApiResponse<Page<CommonCodeGroupResponse>>> getAllGroups(
+    public ResponseEntity<ApiResult<Page<CommonCodeGroupResponse>>> getAllGroups(
             @ParameterObject Pageable pageable){
 
         Page<CommonCodeGroup> groups = commonCodeGroupService.getGroups(pageable);
         Page<CommonCodeGroupResponse> responses = groups.map(CommonCodeGroupResponse::fromWithoutCodes);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 목록 조회", responses));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹 목록 조회", responses));
     }
 
     //공통코드 그룹 검색
     @Operation(summary = "공통코드 그룹 검색", description = "그룹 ID나 그룹명으로 검색합니다.")
     @GetMapping("/common-codes/groups/search")
-    public ResponseEntity<ApiResponse<Page<CommonCodeGroupResponse>>> searchGroups(
+    public ResponseEntity<ApiResult<Page<CommonCodeGroupResponse>>> searchGroups(
             @Parameter(description = "그룹 ID") @RequestParam(required = false) String groupId,
             @Parameter(description = "그룹명") @RequestParam(required = false) String groupName,
             @ParameterObject Pageable pageable){
 
         Page<CommonCodeGroup> groups = commonCodeGroupService.searchGroups(groupId, groupName, pageable);
         Page<CommonCodeGroupResponse> responses = groups.map(CommonCodeGroupResponse::fromWithoutCodes);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 검색 완료", responses));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹 검색 완료", responses));
     }
 
     // 공통코드 그룹 정보 수정
     @Operation(summary = "공통코드 그룹 수정", description = "공통코드 그룹 정보를 수정합니다.")
     @PutMapping("/common-codes/groups/{groupId}")
-    public ResponseEntity<ApiResponse<CommonCodeGroupResponse>> updateGroup(
+    public ResponseEntity<ApiResult<CommonCodeGroupResponse>> updateGroup(
             @Parameter(description = "그룹 ID") @PathVariable String groupId,
             @Valid @RequestBody  CommonCodeGroupRequest request){
 
@@ -104,16 +104,16 @@ public class CommonCodeGroupController {
 
         CommonCodeGroup updateGroup = commonCodeGroupService.getGroup(groupId);
         CommonCodeGroupResponse response = CommonCodeGroupResponse.fromWithoutCodes(updateGroup);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 수정 완료", response));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹 수정 완료", response));
     }
 
     //공통코드 그룹 삭제
     @Operation(summary = "공통코드 그룹 삭제", description = "공통코드 그룹을 삭제합니다. (포함된 코드도 함께 삭제)")
     @DeleteMapping("/common-codes/groups/{groupId}")
-    public ResponseEntity<ApiResponse<Void>> deleteGroup(
+    public ResponseEntity<ApiResult<Void>> deleteGroup(
             @PathVariable String groupId){
 
         commonCodeGroupService.deleteGroup(groupId);
-        return ResponseEntity.ok(ApiResponse.success("공통코드 그룹 삭제 완료"));
+        return ResponseEntity.ok(ApiResult.success("공통코드 그룹 삭제 완료"));
     }
 }

--- a/src/main/java/com/ocp/ocp_finalproject/common/response/ApiResult.java
+++ b/src/main/java/com/ocp/ocp_finalproject/common/response/ApiResult.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ApiResponse<T> {
+public class ApiResult<T> {
 
     @Schema(description = "성공 여부", example = "true")
     private boolean success;
@@ -18,17 +18,17 @@ public class ApiResponse<T> {
     private T data;
 
     //성공 응답 (데이터 O)
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data);
+    public static <T> ApiResult<T> success(String message, T data) {
+        return new ApiResult<>(true, message, data);
     }
 
     //성공 응답 (데이터 x)
-    public static <T> ApiResponse<T> success(String message) {
-        return new ApiResponse<>(true, message, null);
+    public static <T> ApiResult<T> success(String message) {
+        return new ApiResult<>(true, message, null);
     }
 
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(false, message, null);
+    public static <T> ApiResult<T> error(String message) {
+        return new ApiResult<>(false, message, null);
     }
 
 }

--- a/src/main/java/com/ocp/ocp_finalproject/content/controller/ContentJobController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/content/controller/ContentJobController.java
@@ -2,7 +2,7 @@ package com.ocp.ocp_finalproject.content.controller;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.exception.ErrorCode;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.content.domain.ContentJob;
 import com.ocp.ocp_finalproject.content.dto.ContentJobResponse;
 import com.ocp.ocp_finalproject.content.dto.ContentRequestDto;
@@ -26,17 +26,17 @@ public class ContentJobController {
     private final ContentTaskProducer contentTaskProducer;
 
     @PostMapping("/job")
-    public ApiResponse<ContentJobResponse> createJob(@Valid @RequestBody ContentRequestDto requestDto) {
+    public ApiResult<ContentJobResponse> createJob(@Valid @RequestBody ContentRequestDto requestDto) {
         ContentJob job = contentJobService.createJob(requestDto);
         contentTaskProducer.sendTask(job.getJobId(), requestDto);
-        return ApiResponse.success(new ContentJobResponse(job));
+        return ApiResult.success(new ContentJobResponse(job));
     }
 
     @GetMapping("/job/{jobId}")
-    public ApiResponse<ContentJobResponse> getJob(@PathVariable String jobId) {
+    public ApiResult<ContentJobResponse> getJob(@PathVariable String jobId) {
         ContentJob job = contentJobService.getJob(jobId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND, "Job not found: " + jobId));
-        return ApiResponse.success(new ContentJobResponse(job));
+        return ApiResult.success(new ContentJobResponse(job));
     }
 
      */

--- a/src/main/java/com/ocp/ocp_finalproject/controller/TestController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/controller/TestController.java
@@ -2,7 +2,7 @@ package com.ocp.ocp_finalproject.controller;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.exception.ErrorCode;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +19,7 @@ public class TestController {
 
     // 성공 응답 테스트용
     @GetMapping("/success")
-    public ApiResponse<String> testSuccess() {
-        return ApiResponse.success("테스트 성공!");
+    public ApiResult<String> testSuccess() {
+        return ApiResult.success("테스트 성공!");
     }
 }

--- a/src/main/java/com/ocp/ocp_finalproject/user/controller/AuthController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/user/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.ocp.ocp_finalproject.user.controller;
 
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.user.domain.User;
 import com.ocp.ocp_finalproject.user.domain.UserPrincipal;
 import com.ocp.ocp_finalproject.user.dto.response.UserResponse;
@@ -30,7 +30,7 @@ public class AuthController {
      * GET /api/v1/auth/me
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserResponse>> getCurrentUser(@AuthenticationPrincipal UserPrincipal principal) {
+    public ResponseEntity<ApiResult<UserResponse>> getCurrentUser(@AuthenticationPrincipal UserPrincipal principal) {
 
         log.info("현재 사용자 정보 조회 요청");
 
@@ -40,7 +40,7 @@ public class AuthController {
 
         log.info("사용자 정보 조회 성공 - userId: {}",user.getId());
         return ResponseEntity.ok(
-            ApiResponse.success("사용자 상세 조회 성공",response)
+            ApiResult.success("사용자 상세 조회 성공",response)
         );
     }
 
@@ -49,7 +49,7 @@ public class AuthController {
      * POST /api/v1/auth/logout
      */
     @PostMapping("/logout")
-    public ResponseEntity <ApiResponse<Void>> logout(@AuthenticationPrincipal UserPrincipal principal ,HttpServletRequest request) {
+    public ResponseEntity <ApiResult<Void>> logout(@AuthenticationPrincipal UserPrincipal principal ,HttpServletRequest request) {
         log.info("로그아웃 요청 - userId: {}",principal.getUser().getId());
 
         try{
@@ -64,12 +64,12 @@ public class AuthController {
             }
 
             return ResponseEntity.ok(
-                    ApiResponse.success("로그아웃 성공")
+                    ApiResult.success("로그아웃 성공")
             );
         }catch (Exception e){
             log.error("로그아웃 처리 중 에러 발생",e);
             return ResponseEntity.status(500).body(
-                    ApiResponse.error("로그아웃 처리 중 오류가 발생했습니다.")
+                    ApiResult.error("로그아웃 처리 중 오류가 발생했습니다.")
             );
         }
     }
@@ -79,7 +79,7 @@ public class AuthController {
      * DELETE /api/v1/auth/withdraw
      */
     @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Void>> withdraw(@AuthenticationPrincipal UserPrincipal principal, HttpServletRequest request) {
+    public ResponseEntity<ApiResult<Void>> withdraw(@AuthenticationPrincipal UserPrincipal principal, HttpServletRequest request) {
         User user = principal.getUser();
         log.info("회원 작ㄹ퇴 요청 - userId: {}",user.getId());
 
@@ -91,11 +91,11 @@ public class AuthController {
                 session.invalidate();
             }
 
-            return  ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다."));
+            return  ResponseEntity.ok(ApiResult.success("회원 탈퇴가 완료되었습니다."));
         }catch (Exception e){
             log.error("회원 탈퇴 처리 중 에러 발생 - userId: {}",user.getId(),e.getMessage());
             return ResponseEntity.status(500).body(
-                    ApiResponse.error("회원 탈퇴 처리 중 오류가 발생했습니다.")
+                    ApiResult.error("회원 탈퇴 처리 중 오류가 발생했습니다.")
             );
         }
     }

--- a/src/main/java/com/ocp/ocp_finalproject/work/api/BlogUploadWebhookController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/api/BlogUploadWebhookController.java
@@ -2,7 +2,7 @@ package com.ocp.ocp_finalproject.work.api;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.exception.ErrorCode;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.work.config.BlogUploadProperties;
 import com.ocp.ocp_finalproject.work.dto.request.BlogUploadWebhookRequest;
 import com.ocp.ocp_finalproject.work.service.BlogUploadWebhookService;
@@ -24,13 +24,13 @@ public class BlogUploadWebhookController {
     private final BlogUploadProperties blogUploadProperties;
 
     @PostMapping
-    public ApiResponse<Void> handleWebhook(
+    public ApiResult<Void> handleWebhook(
             @RequestHeader(value = "Authorization", required = false) String authorization,
             @RequestBody BlogUploadWebhookRequest request
     ) {
         validateSecret(authorization);
         webhookService.handleResult(request);
-        return ApiResponse.success("블로그 업로드 결과를 처리했습니다.");
+        return ApiResult.success("블로그 업로드 결과를 처리했습니다.");
     }
 
     private void validateSecret(String authorizationHeader) {

--- a/src/main/java/com/ocp/ocp_finalproject/work/api/KeywordSelectWebhookController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/api/KeywordSelectWebhookController.java
@@ -2,7 +2,7 @@ package com.ocp.ocp_finalproject.work.api;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.exception.ErrorCode;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.work.config.KeywordSelectProperties;
 import com.ocp.ocp_finalproject.work.dto.request.KeywordSelectWebhookRequest;
 import com.ocp.ocp_finalproject.work.service.KeywordSelectWebhookService;
@@ -20,13 +20,13 @@ public class KeywordSelectWebhookController {
     private final KeywordSelectWebhookService webhookService;
 
     @PostMapping
-    public ApiResponse<Void> handleWebhook(
+    public ApiResult<Void> handleWebhook(
             @RequestHeader(value = "Authorization", required = false) String authorization,
             @RequestBody KeywordSelectWebhookRequest request
     ) {
         validateSecret(authorization);
         webhookService.handleResult(request);
-        return ApiResponse.success("키워드 선택 결과를 처리했습니다.");
+        return ApiResult.success("키워드 선택 결과를 처리했습니다.");
     }
 
     private void validateSecret(String authorizationHeader) {

--- a/src/main/java/com/ocp/ocp_finalproject/work/api/WorkController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/api/WorkController.java
@@ -1,7 +1,7 @@
 package com.ocp.ocp_finalproject.work.api;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.user.domain.UserPrincipal;
 import com.ocp.ocp_finalproject.work.dto.response.WorkPageResponse;
 import com.ocp.ocp_finalproject.work.service.WorkService;
@@ -26,7 +26,7 @@ public class WorkController {
     private final WorkService workService;
 
     @GetMapping("/{workflowId}")
-    public ResponseEntity<ApiResponse<WorkPageResponse>> getAllWorks(
+    public ResponseEntity<ApiResult<WorkPageResponse>> getAllWorks(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable("workflowId") Long workflowId,
             @RequestParam(value = "page", defaultValue = "0") int page
@@ -38,6 +38,6 @@ public class WorkController {
         Long userId = principal.getUser().getId();
         WorkPageResponse workPage = workService.getWorks(userId, workflowId, page);
 
-        return ResponseEntity.ok(ApiResponse.success("워크 목록 조회 성공", workPage));
+        return ResponseEntity.ok(ApiResult.success("워크 목록 조회 성공", workPage));
     }
 }

--- a/src/main/java/com/ocp/ocp_finalproject/workflow/api/WorkflowController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/workflow/api/WorkflowController.java
@@ -1,6 +1,6 @@
 package com.ocp.ocp_finalproject.workflow.api;
 
-import com.ocp.ocp_finalproject.common.response.ApiResponse;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.workflow.dto.request.*;
 import com.ocp.ocp_finalproject.workflow.dto.response.*;
 import com.ocp.ocp_finalproject.workflow.service.WorkflowService;
@@ -24,35 +24,35 @@ public class WorkflowController {
      * 워크플로우 목록 조회
      */
     @GetMapping("/{userId}")
-    public ResponseEntity<ApiResponse<List<WorkflowListResponse>>> findWorkflows(@PathVariable Long userId) {
+    public ResponseEntity<ApiResult<List<WorkflowListResponse>>> findWorkflows(@PathVariable Long userId) {
 
         List<WorkflowListResponse> workflowList = workflowService.findWorkflows(userId);
 
-        return ResponseEntity.ok(ApiResponse.success("워크플로우 목록 조회 성공", workflowList));
+        return ResponseEntity.ok(ApiResult.success("워크플로우 목록 조회 성공", workflowList));
     }
 
     /**
      * 워크플로우 상세 조회
      */
     @GetMapping("/{userId}/{workflowId}")
-    public ResponseEntity<ApiResponse<WorkflowEditResponse>> getWorkflowEdit(@PathVariable Long userId,
+    public ResponseEntity<ApiResult<WorkflowEditResponse>> getWorkflowEdit(@PathVariable Long userId,
                                                                              @PathVariable Long workflowId) {
 
         WorkflowEditResponse workflow = workflowService.findWorkflow(workflowId, userId);
 
-        return ResponseEntity.ok(ApiResponse.success("워크플로우 상세 조회 성공", workflow));
+        return ResponseEntity.ok(ApiResult.success("워크플로우 상세 조회 성공", workflow));
     }
 
     /**
      * 워크플로우 등록
      */
     @PostMapping("/{userId}")
-    public ResponseEntity<ApiResponse<WorkflowResponse>> createWorkflow(@PathVariable Long userId,
+    public ResponseEntity<ApiResult<WorkflowResponse>> createWorkflow(@PathVariable Long userId,
                                                                         @RequestBody WorkflowRequest workflowRequest) throws SchedulerException {
 
         WorkflowResponse workflow = workflowService.createWorkflow(userId, workflowRequest);
 
-        return ResponseEntity.ok(ApiResponse.success("워크플로우 생성 성공", workflow));
+        return ResponseEntity.ok(ApiResult.success("워크플로우 생성 성공", workflow));
     }
 
     /**
@@ -60,12 +60,12 @@ public class WorkflowController {
      * url, 트렌드 키워드, 블로그, 예약 시간, 블로그 계정 모두 수정 가능
      */
     @PutMapping("/{userId}/{workflowId}")
-    public ResponseEntity<ApiResponse<WorkflowResponse>> updateWorkflow(@PathVariable Long userId,
+    public ResponseEntity<ApiResult<WorkflowResponse>> updateWorkflow(@PathVariable Long userId,
                                                                         @PathVariable Long workflowId,
                                                                         @RequestBody WorkflowRequest workflowRequest) throws SchedulerException {
         WorkflowResponse workflow = workflowService.updateWorkflow(userId, workflowId, workflowRequest);
 
-        return ResponseEntity.ok(ApiResponse.success("워크플로우 수정 성공", workflow));
+        return ResponseEntity.ok(ApiResult.success("워크플로우 수정 성공", workflow));
     }
 
 }


### PR DESCRIPTION


## 📁 관련 이슈
#67 

## 🔥 작업 내용

작업한 내용을 간단히 정리해주세요.
  - com.ocp.ocp_finalproject.common.response.ApiResponse → ApiResult로 클래스명 변경
  - Swagger의 io.swagger.v3.oas.annotations.responses.ApiResponse와의 import 충돌 해결
  - Full package path 사용 제거로 코드 가독성 개선
  - ResponseEntity<ApiResult> 구조로 API 응답의 의미론적 명확성 향상

  영향받은 파일:
  - 공통 응답 클래스: ApiResult.java (renamed)
  - Controller 10개 파일 수정

## 🧪 테스트 결과
<img width="1367" height="901" alt="image" src="https://github.com/user-attachments/assets/fe8c5609-093c-4dea-83a9-52be1a71330e" />

## 📌 추가 확인 사항 (Optional)
리뷰어가 알아야 할 특이 사항이 있다면 작성해주세요.
