### PR TITLE
fix: TrendCategory에 getFullPath 메서드 추가 (#77)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/trend/domain/TrendCategory.java
+++ b/src/main/java/com/ocp/ocp_finalproject/trend/domain/TrendCategory.java
@@ -48,4 +48,16 @@ public class TrendCategory extends BaseEntity {
         this.depth = depth;
         this.parentCategory = parentCategory;
     }
+
+    public List<TrendCategory> getFullPath() {
+        List<TrendCategory> path = new ArrayList<>();
+        TrendCategory current = this;
+
+        while (current != null) {
+            path.add(0, current);
+            current = current.getParentCategory();
+        }
+
+        return path;
+    }
 }


### PR DESCRIPTION
📁 관련 이슈
#77 

🔥 작업 내용
ContentGenerateService에서 사용 중이던 getFullPath() 메서드가
TrendCategory 엔티티에 누락되어 빌드 오류 발생

카테고리의 전체 경로(루트부터 현재까지)를 리스트로 반환하는
getFullPath() 메서드 구현

## 🧪 테스트 결과
잘 돌아갑니다.
