### PR TITLE
refactor: api 패키지를 controller로 통일 (#79)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/notice/controller/admin/NoticeAdminController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/notice/controller/admin/NoticeAdminController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.notice.api.admin;
+package com.ocp.ocp_finalproject.notice.controller.admin;
 
 import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.notice.dto.request.NoticeCreateRequest;

--- a/src/main/java/com/ocp/ocp_finalproject/notice/controller/user/NoticeController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/notice/controller/user/NoticeController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.notice.api.user;
+package com.ocp.ocp_finalproject.notice.controller.user;
 
 import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.notice.dto.response.NoticeResponse;

--- a/src/main/java/com/ocp/ocp_finalproject/work/controller/BlogUploadTestController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/controller/BlogUploadTestController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.work.api;
+package com.ocp.ocp_finalproject.work.controller;
 
 import com.ocp.ocp_finalproject.message.blog.BlogUploadProducer;
 import com.ocp.ocp_finalproject.message.blog.dto.BlogUploadRequest;

--- a/src/main/java/com/ocp/ocp_finalproject/work/controller/BlogUploadWebhookController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/controller/BlogUploadWebhookController.java
@@ -1,36 +1,40 @@
-package com.ocp.ocp_finalproject.work.api;
+package com.ocp.ocp_finalproject.work.controller;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.exception.ErrorCode;
 import com.ocp.ocp_finalproject.common.response.ApiResult;
-import com.ocp.ocp_finalproject.work.config.KeywordSelectProperties;
-import com.ocp.ocp_finalproject.work.dto.request.KeywordSelectWebhookRequest;
-import com.ocp.ocp_finalproject.work.service.KeywordSelectWebhookService;
+import com.ocp.ocp_finalproject.work.config.BlogUploadProperties;
+import com.ocp.ocp_finalproject.work.dto.request.BlogUploadWebhookRequest;
+import com.ocp.ocp_finalproject.work.service.BlogUploadWebhookService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/work/keyword/webhook")
+@RequestMapping("/api/v1/work/blog/webhook")
 @RequiredArgsConstructor
-public class KeywordSelectWebhookController {
+public class BlogUploadWebhookController {
 
-    private final KeywordSelectProperties keywordSelectProperties;
-    private final KeywordSelectWebhookService webhookService;
+    private final BlogUploadWebhookService webhookService;
+    private final BlogUploadProperties blogUploadProperties;
 
     @PostMapping
     public ApiResult<Void> handleWebhook(
             @RequestHeader(value = "Authorization", required = false) String authorization,
-            @RequestBody KeywordSelectWebhookRequest request
+            @RequestBody BlogUploadWebhookRequest request
     ) {
         validateSecret(authorization);
         webhookService.handleResult(request);
-        return ApiResult.success("키워드 선택 결과를 처리했습니다.");
+        return ApiResult.success("블로그 업로드 결과를 처리했습니다.");
     }
 
     private void validateSecret(String authorizationHeader) {
-        String expectedSecret = keywordSelectProperties.getWebhookSecret();
+        String expectedSecret = blogUploadProperties.getWebhookSecret();
         if (expectedSecret == null || expectedSecret.isBlank()) {
             log.warn("웹훅 시크릿이 설정되지 않았습니다.");
             throw new CustomException(ErrorCode.WORK_WEBHOOK_TOKEN_INVALID, "웹훅 시크릿이 설정되지 않았습니다.");

--- a/src/main/java/com/ocp/ocp_finalproject/work/controller/KeywordSelectWebhookController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/controller/KeywordSelectWebhookController.java
@@ -1,40 +1,36 @@
-package com.ocp.ocp_finalproject.work.api;
+package com.ocp.ocp_finalproject.work.controller;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.exception.ErrorCode;
 import com.ocp.ocp_finalproject.common.response.ApiResult;
-import com.ocp.ocp_finalproject.work.config.BlogUploadProperties;
-import com.ocp.ocp_finalproject.work.dto.request.BlogUploadWebhookRequest;
-import com.ocp.ocp_finalproject.work.service.BlogUploadWebhookService;
+import com.ocp.ocp_finalproject.work.config.KeywordSelectProperties;
+import com.ocp.ocp_finalproject.work.dto.request.KeywordSelectWebhookRequest;
+import com.ocp.ocp_finalproject.work.service.KeywordSelectWebhookService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/work/blog/webhook")
+@RequestMapping("/api/v1/work/keyword/webhook")
 @RequiredArgsConstructor
-public class BlogUploadWebhookController {
+public class KeywordSelectWebhookController {
 
-    private final BlogUploadWebhookService webhookService;
-    private final BlogUploadProperties blogUploadProperties;
+    private final KeywordSelectProperties keywordSelectProperties;
+    private final KeywordSelectWebhookService webhookService;
 
     @PostMapping
     public ApiResult<Void> handleWebhook(
             @RequestHeader(value = "Authorization", required = false) String authorization,
-            @RequestBody BlogUploadWebhookRequest request
+            @RequestBody KeywordSelectWebhookRequest request
     ) {
         validateSecret(authorization);
         webhookService.handleResult(request);
-        return ApiResult.success("블로그 업로드 결과를 처리했습니다.");
+        return ApiResult.success("키워드 선택 결과를 처리했습니다.");
     }
 
     private void validateSecret(String authorizationHeader) {
-        String expectedSecret = blogUploadProperties.getWebhookSecret();
+        String expectedSecret = keywordSelectProperties.getWebhookSecret();
         if (expectedSecret == null || expectedSecret.isBlank()) {
             log.warn("웹훅 시크릿이 설정되지 않았습니다.");
             throw new CustomException(ErrorCode.WORK_WEBHOOK_TOKEN_INVALID, "웹훅 시크릿이 설정되지 않았습니다.");

--- a/src/main/java/com/ocp/ocp_finalproject/work/controller/WorkController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/controller/WorkController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.work.api;
+package com.ocp.ocp_finalproject.work.controller;
 
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.response.ApiResult;

--- a/src/main/java/com/ocp/ocp_finalproject/workflow/controller/WorkflowController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/workflow/controller/WorkflowController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.workflow.api;
+package com.ocp.ocp_finalproject.workflow.controller;
 
 import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.workflow.dto.request.*;


### PR DESCRIPTION
## 📁 관련 이슈
#79 

 작업 내용
  - notice.api → notice.controller
  - work.api → work.controller
  - workflow.api → workflow.controller
  - Spring 표준 컨벤션 적용

## 🧪 테스트 결과
잘 됩니다.
