### PR TITLE
feat: 관리자 AI 토큰 사용량 조회 API 구현

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/AdminAiUsageController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/AdminAiUsageController.java
@@ -1,0 +1,116 @@
+package com.ocp.ocp_finalproject.admin.controller;
+
+import com.ocp.ocp_finalproject.admin.dto.response.*;
+import com.ocp.ocp_finalproject.admin.service.AdminAiUsageService;
+import com.ocp.ocp_finalproject.common.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "관리자 - AI 토큰 사용량 관리")
+@RestController
+@RequestMapping("/api/v1/admin/ai-usage")
+@RequiredArgsConstructor
+public class AdminAiUsageController {
+
+    private final AdminAiUsageService adminAiUsageService;
+
+    @Operation(summary = "전체 토큰 사용 현황 요약", description = "전체, 오늘, 이번 달 토큰 사용량 및 비용을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 사용 현황 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResult<AiUsageSummaryResponse>> getUsageSummary() {
+        AiUsageSummaryResponse summary = adminAiUsageService.getUsageSummary();
+        return ResponseEntity.ok(ApiResult.success("토큰 사용 현황 조회 성공", summary));
+    }
+
+    @Operation(summary = "사용자별 토큰 사용 통계", description = "기간별 사용자별 토큰 사용량 및 비용을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자별 통계 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/by-user")
+    public ResponseEntity<ApiResult<List<UserUsageResponse>>> getUserUsageStatistics(
+            @Parameter(description = "시작 날짜 (미입력시 1개월 전)", example = "2025-12-01")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+
+            @Parameter(description = "종료 날짜 (미입력시 오늘)", example = "2025-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<UserUsageResponse> statistics = adminAiUsageService.getUserUsageStatistics(startDate, endDate);
+        return ResponseEntity.ok(ApiResult.success("사용자별 통계 조회 성공", statistics));
+    }
+
+    @Operation(summary = "기능별 토큰 사용 통계", description = "기간별 기능별(콘텐츠 생성, 키워드 추출 등) 토큰 사용량을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "기능별 통계 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/by-feature")
+    public ResponseEntity<ApiResult<List<FeatureUsageResponse>>> getFeatureUsageStatistics(
+            @Parameter(description = "시작 날짜 (미입력시 1개월 전)", example = "2025-12-01")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+
+            @Parameter(description = "종료 날짜 (미입력시 오늘)", example = "2025-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<FeatureUsageResponse> statistics = adminAiUsageService.getFeatureUsageStatistics(startDate, endDate);
+        return ResponseEntity.ok(ApiResult.success("기능별 통계 조회 성공", statistics));
+    }
+
+    @Operation(summary = "일별 토큰 사용 추이", description = "기간별 일별 토큰 사용 추이를 조회합니다. (차트용)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용 추이 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/trends")
+    public ResponseEntity<ApiResult<List<UsageTrendResponse>>> getUsageTrends(
+            @Parameter(description = "시작 날짜 (미입력시 1개월 전)", example = "2025-12-01")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+
+            @Parameter(description = "종료 날짜 (미입력시 오늘)", example = "2025-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        List<UsageTrendResponse> trends = adminAiUsageService.getUsageTrends(startDate, endDate);
+        return ResponseEntity.ok(ApiResult.success("사용 추이 조회 성공", trends));
+    }
+
+    @Operation(summary = "AI 사용 로그 상세 조회", description = "필터링 및 페이지네이션을 지원하는 AI 사용 로그 상세 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/logs")
+    public ResponseEntity<ApiResult<Page<AiUsageLogResponse>>> getUsageLogs(
+            @Parameter(description = "사용자 ID", example = "5")
+            @RequestParam(required = false) Long userId,
+
+            @Parameter(description = "기능 타입", example = "CONTENT_GENERATION")
+            @RequestParam(required = false) String featureType,
+
+            @Parameter(description = "시작 날짜", example = "2025-12-01")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+
+            @Parameter(description = "종료 날짜", example = "2025-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+
+            @ParameterObject Pageable pageable) {
+
+        Page<AiUsageLogResponse> logs = adminAiUsageService.getUsageLogs(userId, featureType, startDate, endDate, pageable);
+        return ResponseEntity.ok(ApiResult.success("로그 조회 성공", logs));
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/request/AiUsageSearchRequest.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/request/AiUsageSearchRequest.java
@@ -1,0 +1,31 @@
+package com.ocp.ocp_finalproject.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AiUsageSearchRequest {
+
+    @Schema(description = "시작 날짜", example = "2025-12-01")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;
+
+    @Schema(description = "종료 날짜", example = "2025-12-16")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+
+    @Schema(description = "사용자 ID (상세 로그 조회용)", example = "5")
+    private Long userId;
+
+    @Schema(description = "기능 타입 (상세 로그 조회용)", example = "CONTENT_GENERATION")
+    private String featureType;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/AiUsageLogResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/AiUsageLogResponse.java
@@ -1,0 +1,63 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import com.ocp.ocp_finalproject.monitoring.domain.AiUsageLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AiUsageLogResponse {
+
+    @Schema(description = "로그 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "사용자 ID", example = "5")
+    private Long userId;
+
+    @Schema(description = "작업 ID", example = "10")
+    private Long workId;
+
+    @Schema(description = "기능 타입", example = "CONTENT_GENERATION")
+    private String featureType;
+
+    @Schema(description = "AI 모델", example = "gpt-4")
+    private String model;
+
+    @Schema(description = "프롬프트 토큰 수", example = "500")
+    private Integer promptTokens;
+
+    @Schema(description = "완성 토큰 수", example = "1500")
+    private Integer completionTokens;
+
+    @Schema(description = "총 토큰 수", example = "2000")
+    private Integer totalTokens;
+
+    @Schema(description = "예상 비용", example = "0.06")
+    private BigDecimal estimatedCost;
+
+    @Schema(description = "생성 일시", example = "2025-12-16T15:30:00")
+    private LocalDateTime createdAt;
+
+    public static AiUsageLogResponse from(AiUsageLog log) {
+        return AiUsageLogResponse.builder()
+                .id(log.getId())
+                .userId(log.getUserId())
+                .workId(log.getWorkId())
+                .featureType(log.getFeatureType())
+                .model(log.getModel())
+                .promptTokens(log.getPromptTokens())
+                .completionTokens(log.getCompletionTokens())
+                .totalTokens(log.getTotalTokens())
+                .estimatedCost(log.getEstimatedCost())
+                .createdAt(log.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/AiUsageSummaryResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/AiUsageSummaryResponse.java
@@ -1,0 +1,40 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AiUsageSummaryResponse {
+
+    @Schema(description = "총 토큰 수", example = "1500000")
+    private Long totalTokens;
+
+    @Schema(description = "총 비용", example = "45.50")
+    private BigDecimal totalCost;
+
+    @Schema(description = "오늘 토큰 수", example = "50000")
+    private Long todayTokens;
+
+    @Schema(description = "오늘 비용", example = "1.50")
+    private BigDecimal todayCost;
+
+    @Schema(description = "이번 달 토큰 수", example = "500000")
+    private Long monthlyTokens;
+
+    @Schema(description = "이번 달 비용", example = "15.00")
+    private BigDecimal monthlyCost;
+
+    @Schema(description = "총 AI 요청 수", example = "3500")
+    private Long totalRequests;
+
+    @Schema(description = "오늘 AI 요청 수", example = "120")
+    private Long todayRequests;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/FeatureUsageResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/FeatureUsageResponse.java
@@ -1,0 +1,31 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FeatureUsageResponse {
+
+    @Schema(description = "기능 타입", example = "CONTENT_GENERATION")
+    private String featureType;
+
+    @Schema(description = "총 토큰 수", example = "800000")
+    private Long totalTokens;
+
+    @Schema(description = "총 비용", example = "24.00")
+    private BigDecimal totalCost;
+
+    @Schema(description = "요청 횟수", example = "500")
+    private Long requestCount;
+
+    @Schema(description = "전체 대비 비율 (%)", example = "53.33")
+    private BigDecimal usagePercentage;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/UsageTrendResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/UsageTrendResponse.java
@@ -1,0 +1,29 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UsageTrendResponse {
+
+    @Schema(description = "날짜", example = "2025-12-16")
+    private LocalDate date;
+
+    @Schema(description = "총 토큰 수", example = "50000")
+    private Long totalTokens;
+
+    @Schema(description = "총 비용", example = "1.50")
+    private BigDecimal totalCost;
+
+    @Schema(description = "요청 횟수", example = "120")
+    private Long requestCount;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/UserUsageResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/UserUsageResponse.java
@@ -1,0 +1,34 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserUsageResponse {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "사용자 이름", example = "홍길동")
+    private String userName;
+
+    @Schema(description = "사용자 이메일", example = "hong@example.com")
+    private String userEmail;
+
+    @Schema(description = "총 토큰 수", example = "250000")
+    private Long totalTokens;
+
+    @Schema(description = "총 비용", example = "7.50")
+    private BigDecimal totalCost;
+
+    @Schema(description = "요청 횟수", example = "150")
+    private Long requestCount;
+}

--- a/src/main/java/com/ocp/ocp_finalproject/admin/service/AdminAiUsageService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/service/AdminAiUsageService.java
@@ -1,0 +1,184 @@
+package com.ocp.ocp_finalproject.admin.service;
+
+import com.ocp.ocp_finalproject.admin.dto.response.*;
+import com.ocp.ocp_finalproject.monitoring.domain.AiUsageLog;
+import com.ocp.ocp_finalproject.monitoring.repository.AiUsageLogRepository;
+import com.ocp.ocp_finalproject.user.domain.User;
+import com.ocp.ocp_finalproject.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAiUsageService {
+
+    private final AiUsageLogRepository aiUsageLogRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 전체 토큰 사용 현황 요약 조회
+     */
+    public AiUsageSummaryResponse getUsageSummary() {
+        // 전체 통계
+        Long totalTokens = aiUsageLogRepository.sumTotalTokens();
+        BigDecimal totalCost = aiUsageLogRepository.sumEstimatedCost();
+
+        // 오늘 통계
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+        LocalDateTime todayEnd = LocalDate.now().atTime(LocalTime.MAX);
+        Long todayTokens = aiUsageLogRepository.sumTotalTokensByDateRange(todayStart, todayEnd);
+        BigDecimal todayCost = aiUsageLogRepository.sumEstimatedCostByDateRange(todayStart, todayEnd);
+
+        // 이번 달 통계
+        LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+        LocalDateTime monthEnd = LocalDate.now().atTime(LocalTime.MAX);
+        Long monthlyTokens = aiUsageLogRepository.sumTotalTokensByDateRange(monthStart, monthEnd);
+        BigDecimal monthlyCost = aiUsageLogRepository.sumEstimatedCostByDateRange(monthStart, monthEnd);
+
+        // 요청 수
+        Long totalRequests = aiUsageLogRepository.count();
+        Long todayRequests = aiUsageLogRepository.findLogsWithFilters(null, null, todayStart, todayEnd, Pageable.unpaged()).getTotalElements();
+
+        return AiUsageSummaryResponse.builder()
+                .totalTokens(totalTokens)
+                .totalCost(totalCost)
+                .todayTokens(todayTokens)
+                .todayCost(todayCost)
+                .monthlyTokens(monthlyTokens)
+                .monthlyCost(monthlyCost)
+                .totalRequests(totalRequests)
+                .todayRequests(todayRequests)
+                .build();
+    }
+
+    /**
+     * 사용자별 토큰 사용 통계 조회
+     */
+    public List<UserUsageResponse> getUserUsageStatistics(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime start = startDate != null ? startDate.atStartOfDay() : LocalDateTime.now().minusMonths(1);
+        LocalDateTime end = endDate != null ? endDate.atTime(LocalTime.MAX) : LocalDateTime.now();
+
+        List<Object[]> statistics = aiUsageLogRepository.findUserUsageStatistics(start, end);
+
+        // userId 목록 추출
+        List<Long> userIds = statistics.stream()
+                .map(row -> (Long) row[0])
+                .collect(Collectors.toList());
+
+        // User 정보 조회
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        return statistics.stream()
+                .map(row -> {
+                    Long userId = (Long) row[0];
+                    Long totalTokens = ((Number) row[1]).longValue();
+                    BigDecimal totalCost = (BigDecimal) row[2];
+                    Long requestCount = ((Number) row[3]).longValue();
+
+                    User user = userMap.get(userId);
+
+                    return UserUsageResponse.builder()
+                            .userId(userId)
+                            .userName(user != null ? user.getName() : "Unknown")
+                            .userEmail(user != null ? user.getEmail() : "Unknown")
+                            .totalTokens(totalTokens)
+                            .totalCost(totalCost)
+                            .requestCount(requestCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 기능별 토큰 사용 통계 조회
+     */
+    public List<FeatureUsageResponse> getFeatureUsageStatistics(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime start = startDate != null ? startDate.atStartOfDay() : LocalDateTime.now().minusMonths(1);
+        LocalDateTime end = endDate != null ? endDate.atTime(LocalTime.MAX) : LocalDateTime.now();
+
+        List<Object[]> statistics = aiUsageLogRepository.findFeatureUsageStatistics(start, end);
+
+        // 전체 토큰 수 계산 (비율 계산용)
+        Long totalTokensAll = statistics.stream()
+                .map(row -> ((Number) row[1]).longValue())
+                .reduce(0L, Long::sum);
+
+        return statistics.stream()
+                .map(row -> {
+                    String featureType = (String) row[0];
+                    Long totalTokens = ((Number) row[1]).longValue();
+                    BigDecimal totalCost = (BigDecimal) row[2];
+                    Long requestCount = ((Number) row[3]).longValue();
+
+                    // 비율 계산
+                    BigDecimal usagePercentage = totalTokensAll > 0
+                            ? BigDecimal.valueOf(totalTokens)
+                            .multiply(BigDecimal.valueOf(100))
+                            .divide(BigDecimal.valueOf(totalTokensAll), 2, RoundingMode.HALF_UP)
+                            : BigDecimal.ZERO;
+
+                    return FeatureUsageResponse.builder()
+                            .featureType(featureType)
+                            .totalTokens(totalTokens)
+                            .totalCost(totalCost)
+                            .requestCount(requestCount)
+                            .usagePercentage(usagePercentage)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 일별 토큰 사용 추이 조회
+     */
+    public List<UsageTrendResponse> getUsageTrends(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime start = startDate != null ? startDate.atStartOfDay() : LocalDateTime.now().minusMonths(1);
+        LocalDateTime end = endDate != null ? endDate.atTime(LocalTime.MAX) : LocalDateTime.now();
+
+        List<Object[]> trends = aiUsageLogRepository.findDailyUsageTrends(start, end);
+
+        return trends.stream()
+                .map(row -> {
+                    LocalDate date = (LocalDate) row[0];
+                    Long totalTokens = ((Number) row[1]).longValue();
+                    BigDecimal totalCost = (BigDecimal) row[2];
+                    Long requestCount = ((Number) row[3]).longValue();
+
+                    return UsageTrendResponse.builder()
+                            .date(date)
+                            .totalTokens(totalTokens)
+                            .totalCost(totalCost)
+                            .requestCount(requestCount)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 상세 로그 조회 (필터링 + 페이지네이션)
+     */
+    public Page<AiUsageLogResponse> getUsageLogs(Long userId, String featureType,
+                                                 LocalDate startDate, LocalDate endDate,
+                                                 Pageable pageable) {
+        LocalDateTime start = startDate != null ? startDate.atStartOfDay() : null;
+        LocalDateTime end = endDate != null ? endDate.atTime(LocalTime.MAX) : null;
+
+        Page<AiUsageLog> logs = aiUsageLogRepository.findLogsWithFilters(userId, featureType, start, end, pageable);
+
+        return logs.map(AiUsageLogResponse::from);
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/monitoring/repository/AiUsageLogRepository.java
+++ b/src/main/java/com/ocp/ocp_finalproject/monitoring/repository/AiUsageLogRepository.java
@@ -1,0 +1,134 @@
+package com.ocp.ocp_finalproject.monitoring.repository;
+
+import com.ocp.ocp_finalproject.monitoring.domain.AiUsageLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AiUsageLogRepository extends JpaRepository<AiUsageLog, Long> {
+
+    /*
+    * 전체 토큰 사용량 합계 조회
+    *
+    * @return 총 토큰 수 (null인 경우 0)
+    * */
+    @Query("SELECT COALESCE(SUM(a.totalTokens), 0) FROM AiUsageLog a")
+    Long sumTotalTokens();
+
+    /*
+    * 전체 예상 비용 합계 조회
+    *
+    * @return 총 예상 비용 (null인 경우 0)
+    * */
+    @Query("SELECT COALESCE(SUM(a.estimatedCost), 0) FROM AiUsageLog a")
+    BigDecimal sumEstimatedCost();
+
+    /*
+    * 기간별 토큰 사용량 합계 조회
+    *
+    * @param startDate 시작 날짜 (포함)
+    * @param endDate 종료 날짜 (포함)
+    * @return 기간 내 총 토큰 수
+    * */
+    @Query("SELECT COALESCE(SUM(a.totalTokens), 0) FROM AiUsageLog a WHERE a.createdAt BETWEEN :startDate AND :endDate")
+    Long sumTotalTokensByDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    /*
+    * 기간별 예상 비용 합계 조회
+    *
+    * @param startDate 시작 날짜 (포함)
+    * @param endDate 종료 날짜 (포함)
+    * @return 기간 내 총 예상 비용
+    * */
+    @Query("SELECT COALESCE(SUM(a.estimatedCost), 0) FROM AiUsageLog a WHERE a.createdAt BETWEEN :startDate AND :endDate")
+    BigDecimal sumEstimatedCostByDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    /*
+    * 사용자별 토큰 사용 통계 조회 (기간 필터링)
+    *
+    * @param startDate 시작 날짜 (포함)
+    * @param endDate 종료 날짜 (포함)
+    * @return 사용자별 통계 리스트 [userId, totalTokens, estimatedCost), requestCount]
+    * */
+    @Query("SELECT a.userId, SUM(a.totalTokens), SUM(a.estimatedCost), COUNT(a)" +
+           "FROM AiUsageLog a " +
+           "WHERE a.createdAt BETWEEN :startDate AND :endDate " +
+           "GROUP BY a.userId " +
+           "ORDER BY SUM(a.totalTokens) DESC")
+    List<Object[]> findUserUsageStatistics(@Param("startDate")LocalDateTime startDate, @Param("endDate")LocalDateTime endDate);
+
+    /*
+    * 기능별 토큰 사용 통계 조회 (기간 필터링)
+    *
+    * @param startDate  시작 날짜 (포함)
+    * @param endDate 종료 날짜 (포함)
+    * @return 일별 통계 리스트 [date, totalTokens, estimatedCost, requestCount]
+    * */
+    @Query("SELECT CAST(a.createdAt AS date), SUM(a.totalTokens), SUM(a.estimatedCost), COUNT(a) "+
+           "FROM AiUsageLog a " +
+           "WHERE a.createdAt BETWEEN :startDate AND :endDate " +
+           "GROUP BY a.featureType " +
+           "ORDER BY SUM(a.totalTokens) DESC" )
+    List<Object[]> findFeatureUsageStatistics(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    /*
+    * 일별 토큰 사용 추이 조회
+    *
+    * @param startDate 시작 날짜 (포함)
+    * @param endDate 종료 날짜 (포함)
+    * @return 일별 통계 리스트 [date, totalTokens, estimatedCost, requestCount]
+    * */
+    @Query("SELECT CAST(a.createdAt AS date ), SUM(a.totalTokens), SUM(a.estimatedCost), COUNT(a) " +
+           "FROM AiUsageLog a " +
+           "WHERE a.createdAt BETWEEN :startDate AND :endDate " +
+           "GROUP BY CAST(a.createdAt AS date) " +
+           "ORDER BY CAST(a.createdAt AS date) ASC" )
+    List<Object[]> findDailyUsageTrends(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    /**
+     * 상세 로그 조회 (필터링 + 페이지네이션)
+     *
+     * @param userId 사용자 ID (null 가능)
+     * @param featureType 기능 타입 (null 가능)
+     * @param startDate 시작 날짜 (null 가능)
+     * @param endDate 종료 날짜 (null 가능)
+     * @param pageable 페이지 정보
+     * @return 로그 페이지
+     */
+    @Query("SELECT a FROM AiUsageLog a " +
+            "WHERE (:userId IS NULL OR a.userId = :userId) " +
+            "AND (:featureType IS NULL OR a.featureType = :featureType) " +
+            "AND (:startDate IS NULL OR a.createdAt >= :startDate) " +
+            "AND (:endDate IS NULL OR a.createdAt <= :endDate) " +
+            "ORDER BY a.createdAt DESC")
+    Page<AiUsageLog> findLogsWithFilters(@Param("userId") Long userId,
+                                         @Param("featureType") String featureType,
+                                         @Param("startDate") LocalDateTime startDate,
+                                         @Param("endDate") LocalDateTime endDate,
+                                         Pageable pageable);
+
+    /**
+     * 특정 사용자의 토큰 사용 내역 조회
+     *
+     * @param userId 사용자 ID
+     * @param pageable 페이지 정보
+     * @return 로그 페이지
+     */
+    Page<AiUsageLog> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * 특정 기능의 토큰 사용 내역 조회
+     *
+     * @param featureType 기능 타입
+     * @param pageable 페이지 정보
+     * @return 로그 페이지
+     */
+    Page<AiUsageLog> findByFeatureTypeOrderByCreatedAtDesc(String featureType, Pageable pageable);
+}


### PR DESCRIPTION
📁 관련 이슈
#131   

🔥 작업 내용
  - AiUsageLogRepository 생성 및 커스텀 쿼리 메서드 추가
  - AdminAiUsageService 비즈니스 로직 구현
  - AdminAiUsageController 및 5개 API 엔드포인트 구현
    - GET /api/v1/admin/ai-usage/summary (전체 요약)
    - GET /api/v1/admin/ai-usage/by-user (사용자별 통계)
    - GET /api/v1/admin/ai-usage/by-feature (기능별 통계)
    - GET /api/v1/admin/ai-usage/trends (일별 추이)
    - GET /api/v1/admin/ai-usage/logs (상세 로그)
  - DTO 클래스 작성 (Request/Response)
 
 🧪 테스트 결과
  
<img width="2810" height="684" alt="image" src="https://github.com/user-attachments/assets/9cdfdcab-fbef-4eb0-b30c-78d89ab20e63" />
