### PR TITLE
refactor: Admin 컨트롤러들을 admin 패키지로 이동(#148)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/AdminUserController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/AdminUserController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.workflow.service.controller;
+package com.ocp.ocp_finalproject.admin.controller;
 
 import com.ocp.ocp_finalproject.admin.dto.request.SuspendUserRequest;
 import com.ocp.ocp_finalproject.admin.dto.response.AdminUserResponse;

--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.workflow.service.controller;
+package com.ocp.ocp_finalproject.admin.controller;
 
 import com.ocp.ocp_finalproject.admin.domain.CommonCode;
 import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;

--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeGroupController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/CommonCodeGroupController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.workflow.service.controller;
+package com.ocp.ocp_finalproject.admin.controller;
 
 import com.ocp.ocp_finalproject.admin.domain.CommonCodeGroup;
 import com.ocp.ocp_finalproject.admin.dto.request.CommonCodeGroupRequest;

--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/StatisticsController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/StatisticsController.java
@@ -1,4 +1,4 @@
-package com.ocp.ocp_finalproject.workflow.service.controller;
+package com.ocp.ocp_finalproject.admin.controller;
 
 //user
 import com.ocp.ocp_finalproject.admin.dto.response.DailyUserStatisticsResponse;


### PR DESCRIPTION
📁 관련 이슈
#148 

🔥 작업 내용
- workflow.service.controller에서 admin.controller로 이동
- AdminUserController, CommonCodeController, CommonCodeGroupController, StatisticsController
- 패키지 구조 명확화

## 🧪 테스트 결과
문제없음
