### PR TITLE
refactor: 용도에 따른 카테고리 dto 분리 및 워크 단건 조회 api 구현

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/work/controller/WorkController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/controller/WorkController.java
@@ -4,6 +4,7 @@ import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.user.domain.UserPrincipal;
 import com.ocp.ocp_finalproject.work.dto.response.WorkPageResponse;
+import com.ocp.ocp_finalproject.work.dto.response.WorkResponse;
 import com.ocp.ocp_finalproject.work.service.WorkService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,5 +40,20 @@ public class WorkController {
         WorkPageResponse workPage = workService.getWorks(userId, workflowId, page);
 
         return ResponseEntity.ok(ApiResult.success("워크 목록 조회 성공", workPage));
+    }
+
+    @GetMapping("/find/{workId}")
+    public ResponseEntity<ApiResult<WorkResponse>> getWork(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("workId") Long workId
+    ) {
+        if (principal == null || principal.getUser() == null) {
+            throw new CustomException(UNAUTHORIZED);
+        }
+
+        Long userId = principal.getUser().getId();
+        WorkResponse work = workService.getWork(userId, workId);
+
+        return ResponseEntity.ok(ApiResult.success("워크 단일 조회 성공", work));
     }
 }

--- a/src/main/java/com/ocp/ocp_finalproject/work/dto/response/WorkResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/dto/response/WorkResponse.java
@@ -1,0 +1,28 @@
+package com.ocp.ocp_finalproject.work.dto.response;
+
+import com.ocp.ocp_finalproject.work.enums.WorkExecutionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class WorkResponse {
+    private Long workId;
+
+    private String postingUrl;
+
+    private LocalDateTime completedAt;
+
+    private String choiceProduct;
+
+    private String title;
+
+    private String content;
+
+    private String choiceTrendKeyword;
+
+    private WorkExecutionStatus status;
+
+}

--- a/src/main/java/com/ocp/ocp_finalproject/work/dto/response/WorkResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/dto/response/WorkResponse.java
@@ -1,6 +1,7 @@
 package com.ocp.ocp_finalproject.work.dto.response;
 
 import com.ocp.ocp_finalproject.work.enums.WorkExecutionStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Builder
 @Getter
+@AllArgsConstructor
 public class WorkResponse {
     private Long workId;
 

--- a/src/main/java/com/ocp/ocp_finalproject/work/repository/WorkRepository.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/repository/WorkRepository.java
@@ -1,6 +1,7 @@
 package com.ocp.ocp_finalproject.work.repository;
 
 import com.ocp.ocp_finalproject.work.domain.Work;
+import com.ocp.ocp_finalproject.work.dto.response.WorkResponse;
 import com.ocp.ocp_finalproject.work.enums.WorkExecutionStatus;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,24 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
         WHERE wf.id = :workflowId
     """)
     Page<Work> findByWorkflowIdForAdmin(Long workflowId, Pageable pageable);
+
+    @Query("""
+        SELECT new com.ocp.ocp_finalproject.work.dto.response.WorkResponse(
+            w.id,
+            w.postingUrl,
+            w.completedAt,
+            ac.choiceProduct,
+            ac.title,
+            ac.content,
+            ac.choiceTrendKeyword,
+            w.status
+        )
+        FROM Work w
+        JOIN w.workflow wf
+        LEFT JOIN w.aiContent ac
+        WHERE w.id = :workId
+    """)
+    WorkResponse findWork(Long workId);
 
     @Query("""
         SELECT w

--- a/src/main/java/com/ocp/ocp_finalproject/work/service/WorkService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/service/WorkService.java
@@ -3,9 +3,12 @@ package com.ocp.ocp_finalproject.work.service;
 import com.ocp.ocp_finalproject.common.exception.CustomException;
 import com.ocp.ocp_finalproject.content.domain.AiContent;
 import com.ocp.ocp_finalproject.content.repository.AiContentRepository;
+import com.ocp.ocp_finalproject.user.domain.User;
+import com.ocp.ocp_finalproject.user.repository.UserRepository;
 import com.ocp.ocp_finalproject.work.domain.Work;
 import com.ocp.ocp_finalproject.work.dto.response.WorkListResponse;
 import com.ocp.ocp_finalproject.work.dto.response.WorkPageResponse;
+import com.ocp.ocp_finalproject.work.dto.response.WorkResponse;
 import com.ocp.ocp_finalproject.work.repository.WorkRepository;
 import com.ocp.ocp_finalproject.workflow.domain.Workflow;
 import com.ocp.ocp_finalproject.workflow.repository.WorkflowRepository;
@@ -28,6 +31,7 @@ public class WorkService {
     private final WorkRepository workRepository;
     private final WorkflowRepository workflowRepository;
     private final AiContentRepository aiContentRepository;
+    private final UserRepository userRepository;
 
     private static final int DEFAULT_PAGE_SIZE = 10;
 
@@ -66,6 +70,29 @@ public class WorkService {
                 .totalElements(workPage.getTotalElements())
                 .totalPages(workPage.getTotalPages())
                 .last(workPage.isLast())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public WorkResponse getWork(Long userId, Long workId) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        workRepository.findById(workId)
+                .orElseThrow(() -> new CustomException(WORK_NOT_FOUND));
+
+        WorkResponse work = workRepository.findWork(workId);
+
+        return WorkResponse.builder()
+                .workId(work.getWorkId())
+                .postingUrl(work.getPostingUrl())
+                .completedAt(work.getCompletedAt())
+                .title(work.getTitle())
+                .content(work.getContent())
+                .choiceProduct(work.getChoiceProduct())
+                .choiceTrendKeyword(work.getChoiceTrendKeyword())
+                .status(work.getStatus())
                 .build();
     }
 

--- a/src/main/java/com/ocp/ocp_finalproject/work/service/WorkService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/work/service/WorkService.java
@@ -76,22 +76,23 @@ public class WorkService {
     @Transactional(readOnly = true)
     public WorkResponse getWork(Long userId, Long workId) {
 
-        userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
-        workRepository.findById(workId)
+        Work work = workRepository.findById(workId)
                 .orElseThrow(() -> new CustomException(WORK_NOT_FOUND));
 
-        WorkResponse work = workRepository.findWork(workId);
+        if (!work.getWorkflow().getUser().getId().equals(userId)) {
+            throw new CustomException(NOT_WORKFLOW_OWNER);
+        }
+
+        AiContent aiContent = work.getAiContent();
 
         return WorkResponse.builder()
-                .workId(work.getWorkId())
+                .workId(work.getId())
                 .postingUrl(work.getPostingUrl())
                 .completedAt(work.getCompletedAt())
-                .title(work.getTitle())
-                .content(work.getContent())
-                .choiceProduct(work.getChoiceProduct())
-                .choiceTrendKeyword(work.getChoiceTrendKeyword())
+                .title(aiContent != null ? aiContent.getTitle() : null)
+                .content(aiContent != null ? aiContent.getContent() : null)
+                .choiceProduct(aiContent != null ? aiContent.getChoiceProduct() : null)
+                .choiceTrendKeyword(aiContent != null ? aiContent.getChoiceTrendKeyword() : null)
                 .status(work.getStatus())
                 .build();
     }

--- a/src/main/java/com/ocp/ocp_finalproject/workflow/dto/SetTrendCategoryIdDto.java
+++ b/src/main/java/com/ocp/ocp_finalproject/workflow/dto/SetTrendCategoryIdDto.java
@@ -19,15 +19,34 @@ public class SetTrendCategoryIdDto {
     private Long depth3Category;
 
     public static SetTrendCategoryIdDto from(TrendCategory category) {
+        TrendCategory parent = category.getParentCategory();
+        TrendCategory grandParent = (parent != null) ? parent.getParentCategory() : null;
 
-        TrendCategory d2 = category.getParentCategory();
-        TrendCategory d1 = (d2 != null) ? d2.getParentCategory() : null;
+        Long depth1Id;
+        Long depth2Id;
+        Long depth3Id;
+
+        if (parent == null) {
+            // 부모가 없으면 category가 depth1
+            depth1Id = category.getId();
+            depth2Id = null;
+            depth3Id = null;
+        } else if (grandParent == null) {
+            // 조부모가 없으면 category가 depth2
+            depth1Id = parent.getId();
+            depth2Id = category.getId();
+            depth3Id = null;
+        } else {
+            // 조부모가 있으면 category가 depth3
+            depth1Id = grandParent.getId();
+            depth2Id = parent.getId();
+            depth3Id = category.getId();
+        }
 
         return SetTrendCategoryIdDto.builder()
-                .depth1Category(d1 != null ? d1.getId() : null)
-                .depth2Category(d2 != null ? d2.getId() : null)
-                .depth3Category(category.getId())
+                .depth1Category(depth1Id)
+                .depth2Category(depth2Id)
+                .depth3Category(depth3Id)
                 .build();
     }
-
 }

--- a/src/main/java/com/ocp/ocp_finalproject/workflow/dto/SetTrendCategoryNameDto.java
+++ b/src/main/java/com/ocp/ocp_finalproject/workflow/dto/SetTrendCategoryNameDto.java
@@ -17,14 +17,34 @@ public class SetTrendCategoryNameDto {
     private String depth3Category;
 
     public static SetTrendCategoryNameDto from(TrendCategory category) {
+        TrendCategory parent = category.getParentCategory();
+        TrendCategory grandParent = (parent != null) ? parent.getParentCategory() : null;
 
-        TrendCategory d2 = category.getParentCategory();
-        TrendCategory d1 = (d2 != null) ? d2.getParentCategory() : null;
+        String depth1Name;
+        String depth2Name;
+        String depth3Name;
+
+        if (parent == null) {
+            // 부모가 없으면 category가 depth1
+            depth1Name = category.getTrendCategoryName();
+            depth2Name = null;
+            depth3Name = null;
+        } else if (grandParent == null) {
+            // 조부모가 없으면 category가 depth2
+            depth1Name = parent.getTrendCategoryName();
+            depth2Name = category.getTrendCategoryName();
+            depth3Name = null;
+        } else {
+            // 조부모가 있으면 category가 depth3
+            depth1Name = grandParent.getTrendCategoryName();
+            depth2Name = parent.getTrendCategoryName();
+            depth3Name = category.getTrendCategoryName();
+        }
 
         return SetTrendCategoryNameDto.builder()
-                .depth1Category(d1 != null ? d1.getTrendCategoryName() : null)
-                .depth2Category(d2 != null ? d2.getTrendCategoryName() : null)
-                .depth3Category(category.getTrendCategoryName())
+                .depth1Category(depth1Name)
+                .depth2Category(depth2Name)
+                .depth3Category(depth3Name)
                 .build();
     }
 

--- a/src/main/java/com/ocp/ocp_finalproject/workflow/service/WorkflowServiceImpl.java
+++ b/src/main/java/com/ocp/ocp_finalproject/workflow/service/WorkflowServiceImpl.java
@@ -74,6 +74,7 @@ public class WorkflowServiceImpl implements WorkflowService {
                 .blogAccountId(wf.getBlogAccountId())
                 .readableRule(wf.getReadableRule())
                 .status(wf.getStatus())
+                .testStatus(wf.getTestStatus())
                 .build());
     }
 


### PR DESCRIPTION
## 📁 관련 이슈
#140 

<br>

## 🔥 작업 내용
id용 dto와 표시용 name dto를 분리하였습니다.

<br>

## 🧪 테스트 결과
.

<br>

## 📌 추가 확인 사항 (Optional)
.
