### PR TITLE
 fix: 통계 데이터 누락 및 날짜 범위 표시 오류 수정 (#154)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/admin/service/StatisticsService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/service/StatisticsService.java
@@ -341,9 +341,9 @@ public class StatisticsService {
                     Integer monthNumber = entry.getKey();
                     List<SystemDailyStatistics> monthData = entry.getValue();
 
-                    // 월의 시작일과 종료일
-                    LocalDate monthStart = monthData.get(0).getStatDate();
-                    LocalDate monthEnd = monthData.get(monthData.size() - 1).getStatDate();
+                    // 월의 시작일과 종료일 (해당 월의 실제 첫날과 마지막 날)
+                    LocalDate monthStart = LocalDate.of(year, monthNumber, 1);
+                    LocalDate monthEnd = monthStart.plusMonths(1).minusDays(1);
 
                     // 월간 총 포스팅 수 (합계)
                     long totalPosts = monthData.stream()

--- a/src/main/java/com/ocp/ocp_finalproject/monitoring/repository/SystemDailyStatisticsRepository.java
+++ b/src/main/java/com/ocp/ocp_finalproject/monitoring/repository/SystemDailyStatisticsRepository.java
@@ -38,4 +38,13 @@ public interface SystemDailyStatisticsRepository extends JpaRepository<SystemDai
     * @return 존재 여부
     * */
     boolean existsByStatDate(LocalDate date);
+
+    /*
+    * 특정 날짜의 통계 삭제
+    *
+    * 통계 재집계 시 기존 데이터를 삭제하기 위해 사용
+    *
+    * @param date 삭제할 날짜
+    * */
+    void deleteByStatDate(LocalDate date);
 }

--- a/src/main/java/com/ocp/ocp_finalproject/monitoring/service/StatisticsAggregationService.java
+++ b/src/main/java/com/ocp/ocp_finalproject/monitoring/service/StatisticsAggregationService.java
@@ -147,4 +147,25 @@ public class StatisticsAggregationService {
         Long count = userRepository.countActiveUsersBetween(startTime, endTime);
         return Math.toIntExact(count);
     }
+
+    /*
+    * 특정 날짜의 통계를 재집계합니다.
+    *
+    * 기존 통계 데이터가 있으면 삭제한 후 새로 집계합니다.
+    * 수동으로 통계를 재집계할 때 사용합니다.
+    *
+    * @param targetDate 재집계할 날짜
+    * */
+    @Transactional
+    public void reAggregateStatistics(LocalDate targetDate) {
+        log.info("통계 재집계 시작 - 날짜: {}", targetDate);
+
+        // 1. 기존 통계 데이터 삭제
+        systemDailyStatisticsRepository.deleteByStatDate(targetDate);
+        log.info("기존 통계 데이터 삭제 완료 - 날짜: {}", targetDate);
+
+        // 2. 새로 집계
+        aggregateAndSaveDailyStatistics(targetDate);
+        log.info("통계 재집계 완료 - 날짜: {}", targetDate);
+    }
 }


### PR DESCRIPTION
📁 관련 이슈
#154

🔥 작업 내용
  - 통계 수동 재집계 API 추가
    - POST /api/v1/admin/statistics/manual-aggregate (단일 날짜)
    - POST /api/v1/admin/statistics/manual-aggregate-range (날짜 범위)
  - SystemDailyStatisticsRepository에 deleteByStatDate 메서드 추가
  - StatisticsAggregationService에 reAggregateStatistics 메서드 추가
  - 월별 포스팅 통계의 날짜 범위 로직 개선
    - startDate, endDate를 해당 월의 실제 시작일/종료일로 계산
    - 데이터 누락 여부와 무관하게 일관된 날짜 범위 표시

🧪 테스트 결과
<img width="1286" height="548" alt="image" src="https://github.com/user-attachments/assets/1f4f6a5c-a123-4265-b9d8-3511b1aeb5f3" />
