### PR TITLE
feat: 블로그 플랫폼별 발행 통계 조회 API 구현 (#158)

### DIFF
--- a/src/main/java/com/ocp/ocp_finalproject/admin/controller/StatisticsController.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/controller/StatisticsController.java
@@ -8,6 +8,7 @@ import com.ocp.ocp_finalproject.admin.dto.response.WeeklyUserStatisticsResponse;
 import com.ocp.ocp_finalproject.admin.dto.response.DailyPostStatisticsResponse;
 import com.ocp.ocp_finalproject.admin.dto.response.WeeklyPostStatisticsResponse;
 import com.ocp.ocp_finalproject.admin.dto.response.MonthlyPostStatisticsResponse;
+import com.ocp.ocp_finalproject.admin.dto.response.BlogPlatformStatisticsResponse;
 import com.ocp.ocp_finalproject.admin.service.StatisticsService;
 import com.ocp.ocp_finalproject.common.response.ApiResult;
 import com.ocp.ocp_finalproject.monitoring.service.StatisticsAggregationService;
@@ -403,6 +404,54 @@ public class StatisticsController {
         return ResponseEntity.ok(
                 ApiResult.success("통계 재집계 완료", startDate + " ~ " + endDate)
         );
+    }
+
+    // ============================================
+    // 플랫폼별 발행 통계
+    // ============================================
+
+    /*
+     * 플랫폼별 발행 통계를 조회합니다.
+     *
+     * 지정된 기간의 블로그 플랫폼별 발행된 포스팅 수를 조회합니다.
+     *
+     * @param startDate 조회 시작 날짜
+     * @param endDate 조회 종료 날짜
+     * @return 플랫폼별 발행 통계 리스트
+     * */
+    @Operation(summary = "플랫폼별 발행 통계 조회",
+            description = "지정한 기간의 블로그 플랫폼별 발행된 포스팅 수를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "플랫폼별 통계 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (날짜 형식 오류, 시작일 > 종료일 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 전용)"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/blog-platforms")
+    public ResponseEntity<ApiResult<List<BlogPlatformStatisticsResponse>>> getBlogPlatformStatistics(
+            @Parameter(
+                    description = "조회 시작 날짜 (ISO-8601 형식)",
+                    example = "2025-12-01",
+                    required = true
+            )
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+
+            @Parameter(
+                    description = "조회 종료 날짜 (ISO-8601 형식)",
+                    example = "2025-12-31",
+                    required = true
+            )
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate) {
+
+        List<BlogPlatformStatisticsResponse> statistics =
+                statisticsService.getBlogPlatformStatistics(startDate, endDate);
+
+        return ResponseEntity.ok(ApiResult.success("플랫폼별 발행 통계 조회 성공", statistics));
     }
 }
 

--- a/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/BlogPlatformStatisticsResponse.java
+++ b/src/main/java/com/ocp/ocp_finalproject/admin/dto/response/BlogPlatformStatisticsResponse.java
@@ -1,0 +1,37 @@
+package com.ocp.ocp_finalproject.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BlogPlatformStatisticsResponse {
+
+    /**
+     * 블로그 플랫폼 이름
+     * 예: "티스토리", "네이버"
+     */
+    private String platformName;
+
+    /**
+     * 발행된 포스팅 수
+     */
+    private Long postCount;
+
+    /**
+     * Object[] 쿼리 결과를 DTO로 변환
+     *
+     * @param result [String platformName, Long postCount]
+     * @return BlogPlatformStatisticsResponse
+     */
+    public static BlogPlatformStatisticsResponse from(Object[] result) {
+        return BlogPlatformStatisticsResponse.builder()
+                .platformName((String) result[0])
+                .postCount(((Number) result[1]).longValue())
+                .build();
+    }
+}

--- a/src/main/java/com/ocp/ocp_finalproject/content/repository/AiContentRepository.java
+++ b/src/main/java/com/ocp/ocp_finalproject/content/repository/AiContentRepository.java
@@ -76,4 +76,29 @@ public interface AiContentRepository extends JpaRepository<AiContent, Long> {
      * @return 해당 기간의 콘텐츠 수
      */
     Long countByStatusAndCompletedAtBetween(ContentStatus status, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    /*
+     * 플랫폼별 발행된 포스팅 수 조회
+     *
+     * @param startDateTime 시작 날짜-시간 (포함)
+     * @param endDateTime 종료 날짜-시간 (미포함)
+     * @return [String platformName, Long postCount] 형식의 Object[] 리스트
+     */
+    @Query("""
+        SELECT bt.blogTypeName, COUNT(ac)
+        FROM AiContent ac
+        JOIN ac.work w
+        JOIN w.workflow wf
+        JOIN wf.userBlog ub
+        JOIN ub.blogType bt
+        WHERE ac.status = 'PUBLISHED'
+            AND ac.completedAt >= :startDateTime
+            AND ac.completedAt < :endDateTime
+        GROUP BY bt.blogTypeName
+        ORDER BY COUNT(ac) DESC
+    """)
+    List<Object[]> countByBlogPlatform(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 }


### PR DESCRIPTION
## 📁 관련 이슈
#158 

## 🔥 작업 내용
- GET /api/v1/admin/statistics/blog-platforms 엔드포인트 추가
- 날짜 범위 기반 플랫폼별 발행 포스팅 수 집계
- AiContentRepository.countByBlogPlatform() 쿼리 메서드 추가
- BlogPlatformStatisticsResponse DTO 추가

## 🧪 테스트 결과
good